### PR TITLE
🐛 FIX: CSS styling

### DIFF
--- a/quantecon_book_theme/scss/quantecon-book-theme.scss
+++ b/quantecon_book_theme/scss/quantecon-book-theme.scss
@@ -338,6 +338,11 @@ tt {
       margin: 0;
     }
   }
+  // Math equations
+  span.eqno {
+    float: right;
+    font-size: 1.2em;
+  }
 }
 
 .sidebar {


### PR DESCRIPTION
This PR at present fixes CSS styling for labels in math equations

<img width="1530" alt="Screen Shot 2020-10-01 at 2 55 33 pm" src="https://user-images.githubusercontent.com/6542997/94769959-a3361200-03f6-11eb-980a-0c415ae1900a.png">

closes https://github.com/QuantEcon/quantecon-book-theme/issues/12
