### PR TITLE
🐛 BUG: download links

### DIFF
--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -152,9 +152,9 @@
 
                 <ul class="toolbar__links">
                     <li data-tippy-content="Home"><a href="/"><i data-feather="home"></i></a></li>
-                    <li data-tippy-content="Download Notebook"><a href="{{ pathto('_sources', 1) }}/{{ ipynb_source }}"><i data-feather="download-cloud"></i></a></li>
+                    <li data-tippy-content="Download Notebook"><a href="{{ pathto('_sources', 1) }}/{{ ipynb_source }}" download><i data-feather="download-cloud"></i></a></li>
                     <li data-tippy-content="Download PDF" onClick="window.print()"><i data-feather="file"></i></li>
-                    <li data-tippy-content="View Source"><a href="{{ pathto('_sources', 1) }}/{{ sourcename }}"><i data-feather="github"></i></a></li>
+                    <li data-tippy-content="View Source"><a href="{{ pathto('_sources', 1) }}/{{ sourcename }}" download><i data-feather="github"></i></a></li>
                 </ul>
 
             </div>


### PR DESCRIPTION
The `view source` and `download ipynb` links were opening the asset instead of downloading them in **netlify**. This PR tries to fix that.