### PR TITLE
🐛 BUG: header buttons were missing in local previews

### DIFF
--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -165,13 +165,13 @@
     </div> <!-- .wrapper-->
 
 <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-<script src="/_static/plugins.js"></script>
+<script src="_static/plugins.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
 <script src="https://unpkg.com/@popperjs/core@2"></script>
 <script src="https://unpkg.com/tippy.js@6"></script>
 
-<script src="/_static/scripts.js"></script>
+<script src="_static/scripts.js"></script>
 <script>
     feather.replace()
     tippy('[data-tippy-content]');

--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -152,7 +152,9 @@
 
                 <ul class="toolbar__links">
                     <li data-tippy-content="Home"><a href="/"><i data-feather="home"></i></a></li>
+                    {% if ipynb_source %}
                     <li data-tippy-content="Download Notebook"><a href="{{ pathto('_sources', 1) }}/{{ ipynb_source }}" download><i data-feather="download-cloud"></i></a></li>
+                    {% endif %}
                     <li data-tippy-content="Download PDF" onClick="window.print()"><i data-feather="file"></i></li>
                     <li data-tippy-content="View Source"><a href="{{ pathto('_sources', 1) }}/{{ sourcename }}" download><i data-feather="github"></i></a></li>
                 </ul>

--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -152,9 +152,9 @@
 
                 <ul class="toolbar__links">
                     <li data-tippy-content="Home"><a href="/"><i data-feather="home"></i></a></li>
-                    <li data-tippy-content="Download Notebook"><a href="{{ pathto('_sources', 1) }}/{{ ipynb_source }}"><i data-feather="download-cloud"></i></a></li>
+                    <li data-tippy-content="Download Notebook"><a href="{{ pathto('_sources', 1) }}/{{ ipynb_source }}" download><i data-feather="download-cloud"></i></a></li>
                     <li data-tippy-content="Download PDF" onClick="window.print()"><i data-feather="file"></i></li>
-                    <li data-tippy-content="View Source"><a href="{{ pathto('_sources', 1) }}/{{ sourcename }}"><i data-feather="github"></i></a></li>
+                    <li data-tippy-content="View Source"><a href="{{ pathto('_sources', 1) }}/{{ sourcename }}" download><i data-feather="github"></i></a></li>
                 </ul>
 
             </div>

--- a/tests/test_build/test_build_book.html
+++ b/tests/test_build/test_build_book.html
@@ -1,4 +1,4 @@
-<div class="sidebar bd-sidebar" id="site-navigation">
+<div class="sidebar bd-sidebar inactive" id="site-navigation">
  <div class="sidebar__header">
   Contents
  </div>


### PR DESCRIPTION
Thanks @DrDrij for the solution. This PR makes the header icons available in local previews.

TODO: 

- [x]  implement the functionality of header buttons to work on local previews

fixes https://github.com/QuantEcon/quantecon-book-theme/issues/10