### PR TITLE
✨ NEW: Add config support to specify javascript plugins

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -101,3 +101,16 @@ html_theme_options = {
     ...
 }
 ```
+
+## Use plugins to add/extend features
+
+If you want some extra features in your documentation website or modify an existing one, you can add a list of plugins
+in javascript format, to suit your needs:
+
+```python
+html_theme_options = {
+    ...
+    "plugins_list": ["path-relative-to-config-file.js"]
+    ...
+}
+```

--- a/quantecon_book_theme/__init__.py
+++ b/quantecon_book_theme/__init__.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from docutils.parsers.rst import directives
 from docutils import nodes
 from sphinx.util import logging
+from sphinx.util.fileutil import copy_asset
+from sphinx.util.osutil import ensuredir
 from bs4 import BeautifulSoup as bs
 from sass import compile as sass_compile
 
@@ -30,6 +32,15 @@ def add_static_path(app):
         source_dir = str(static_path.parent / "scss")
         output_dir = str(static_path)
         sass_compile(dirname=(source_dir, output_dir), output_style="compressed")
+
+    # copying plugins
+    if "plugins_list" in app.config.html_theme_options:
+        outdir = app.outdir + "/plugins"
+        ensuredir(outdir)
+        for i, asset in enumerate(app.config.html_theme_options["plugins_list"]):
+            assetname = Path(asset).name
+            copy_asset(app.confdir + "/" + asset, outdir)
+            app.config.html_theme_options["plugins_list"][i] = "plugins/" + assetname
 
 
 def find_url_relative_to_root(pagename, relative_page, path_docs_source):

--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -173,6 +173,9 @@
 <script src="https://unpkg.com/@popperjs/core@2"></script>
 <script src="https://unpkg.com/tippy.js@6"></script>
 
+{% for item in theme_plugins_list %}
+    <script src={{item}}></script>
+{% endfor %}
 <script src="_static/scripts.js"></script>
 <script>
     feather.replace()

--- a/quantecon_book_theme/theme.conf
+++ b/quantecon_book_theme/theme.conf
@@ -16,3 +16,4 @@ extra_navbar = Theme by the <a href="https://quantecon.org/">QuantEcon</a>
 extra_footer =
 use_issues_button = False
 use_repository_button = False
+plugins_list = []


### PR DESCRIPTION
We can now add extra features in the documentation website or modify an existing one, using plugins in javascript files.

config option is:

```
html_theme_options = {
     "plugins_list": ["path-relative-to-config-file.js"]
}
```

or in jb:

```
sphinx:
    html_theme_options:
      plugins_list: ['path-relative-to-config-file.js']
```

The background implementation is basically copying all the js files specified in `plugins_list` to a new `plugins` directory in outdir of the build. And including script tags pointing to these js files in the base HTML file of the website.