### PR TITLE
🐛 BUG: google analytics_id in layout

### DIFF
--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -49,7 +49,7 @@
 
 
                         <nav id="bd-toc-nav" class="page__toc-nav">
-                            
+
                             <ul class="nav section-nav flex-column">
                                 {% for item in page_toc recursive %}
                                 <li class="nav-item toc-entry toc-h{{ loop.depth + 1 }}">
@@ -190,14 +190,14 @@
     tippy('[data-tippy-content]');
 </script>
 
-{% if google_analytics_id %}
+{% if theme_google_analytics_id %}
 <script>
     window.ga = function () {
         ga.q.push(arguments);
     };
     ga.q = [];
     ga.l = +new Date();
-    ga("create", "{{ google_analytics_id }}", "auto");
+    ga("create", "{{ theme_google_analytics_id }}", "auto");
     ga("set", "anonymizeIp", true);
     ga("set", "transport", "beacon");
     ga("send", "pageview");

--- a/tests/test_build/test_build_book.html
+++ b/tests/test_build/test_build_book.html
@@ -34,12 +34,5 @@
   </ul>
  </nav>
  <div class="sidebar__footer">
-  <p>
-   <img src="https://python-programming.quantecon.org/_static/img/qe-logo.png"/>
-  </p>
-  Theme by the
-  <a href="https://quantecon.org/">
-   QuantEcon
-  </a>
  </div>
 </div>


### PR DESCRIPTION
To read google_analytics_id variable, we need to prepend it with `theme_`, as all variables in `html_theme_options` of sphinx get prepended with that automatically by sphinx. 