### PR TITLE
Add QE logo to toolbar,  rearrange icons, fixed sidebar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install quantecon-book-theme
         shell: bash -l {0}
         run: |
-          pip uninstall quantecon-book-theme
+          pip uninstall -y quantecon-book-theme
           python setup.py install
       - name: Install sphinx-multitoc-numbering
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Install quantecon-book-theme
         shell: bash -l {0}
         run: |
+          pip uninstall quantecon-book-theme
           python setup.py install
       - name: Install sphinx-multitoc-numbering
         shell: bash -l {0}

--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -143,33 +143,6 @@
 
             <div class="toolbar__inner">
 
-
-                <ul class="toolbar__main">
-                    <li data-tippy-content="table of contents" class="btn__sidebar"><i data-feather="menu"></i></li>
-                    <!-- <li class="btn__search">
-                        <form action="search.html" method="get">
-                            <input type="search" class="form-control" name="q" id="search-input" placeholder="Search the docs ..." aria-label="Search the docs ..." autocomplete="off">
-                            <i data-feather="search"></i>
-                        </form>
-                    </li> -->
-                    <li data-tippy-content="Home"><a href="intro.html"><i data-feather="home"></i></a></li>
-                    <li class="btn__qelogo"><a href="https://quantecon.org/" title="quantecon.org"><span class="show-for-sr">QuantEcon</span></a></li>
-                </ul>
-
-                <ul class="toolbar__links">
-                    <li data-tippy-content="Fullscreen" class="btn__fullscreen"><i data-feather="maximize"></i></li>
-                    <li data-tippy-content="Increase font size" class="btn__plus"><i data-feather="plus-circle"></i></li>
-                    <li data-tippy-content="Decrease font size" class="btn__minus"><i data-feather="minus-circle"></i></li>
-                    <li data-tippy-content="Change contrast" class="btn__contrast"><i data-feather="sunset"></i></li>
-                    <li data-tippy-content="Download PDF" onClick="window.print()"><i data-feather="file"></i></li>
-                    <li data-tippy-content="View Source"><a href="_sources/numpy.md" download><i data-feather="github"></i></a></li>
-                </ul>
-
-            </div>
-
-            <div class="toolbar__inner">
-
-
                 <ul class="toolbar__main">
                     <li data-tippy-content="Table of Contents" class="btn__sidebar"><i data-feather="menu"></i></li>
                     <li data-tippy-content="Home"><a href="{{ master_doc }}.html"><i data-feather="home"></i></a></li>

--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -49,7 +49,7 @@
 
 
                         <nav id="bd-toc-nav" class="page__toc-nav">
-                            
+
                             <ul class="nav section-nav flex-column">
                                 {% for item in page_toc recursive %}
                                 <li class="nav-item toc-entry toc-h{{ loop.depth + 1 }}">
@@ -160,7 +160,7 @@
                     <li data-tippy-content="Fullscreen" class="btn__fullscreen"><i data-feather="maximize"></i></li>
                     <li data-tippy-content="Increase font size" class="btn__plus"><i data-feather="plus-circle"></i></li>
                     <li data-tippy-content="Decrease font size" class="btn__minus"><i data-feather="minus-circle"></i></li>
-                    <li data-tippy-content="Change contrast" class="btn__contrast"><i data-feather="sunset"></i></li>                    
+                    <li data-tippy-content="Change contrast" class="btn__contrast"><i data-feather="sunset"></i></li>
                     <li data-tippy-content="Download PDF" onClick="window.print()"><i data-feather="file"></i></li>
                     <li data-tippy-content="View Source"><a href="_sources/numpy.md" download><i data-feather="github"></i></a></li>
                 </ul>

--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -146,20 +146,47 @@
 
                 <ul class="toolbar__main">
                     <li data-tippy-content="table of contents" class="btn__sidebar"><i data-feather="menu"></i></li>
-                    <li class="btn__search">
+                    <!-- <li class="btn__search">
+                        <form action="search.html" method="get">
+                            <input type="search" class="form-control" name="q" id="search-input" placeholder="Search the docs ..." aria-label="Search the docs ..." autocomplete="off">
+                            <i data-feather="search"></i>
+                        </form>
+                    </li> -->
+                    <li data-tippy-content="Home"><a href="intro.html"><i data-feather="home"></i></a></li>
+                    <li class="btn__qelogo"><a href="https://quantecon.org/" title="quantecon.org"><span class="show-for-sr">QuantEcon</span></a></li>
+                </ul>
+
+                <ul class="toolbar__links">
+                    <li data-tippy-content="Fullscreen" class="btn__fullscreen"><i data-feather="maximize"></i></li>
+                    <li data-tippy-content="Increase font size" class="btn__plus"><i data-feather="plus-circle"></i></li>
+                    <li data-tippy-content="Decrease font size" class="btn__minus"><i data-feather="minus-circle"></i></li>
+                    <li data-tippy-content="Change contrast" class="btn__contrast"><i data-feather="sunset"></i></li>                    
+                    <li data-tippy-content="Download PDF" onClick="window.print()"><i data-feather="file"></i></li>
+                    <li data-tippy-content="View Source"><a href="_sources/numpy.md" download><i data-feather="github"></i></a></li>
+                </ul>
+
+            </div>
+
+            <div class="toolbar__inner">
+
+
+                <ul class="toolbar__main">
+                    <li data-tippy-content="Table of Contents" class="btn__sidebar"><i data-feather="menu"></i></li>
+                    <li data-tippy-content="Home"><a href="{{ master_doc }}.html"><i data-feather="home"></i></a></li>
+                    <li class="btn__qelogo"><a href="https://quantecon.org/" title="quantecon.org"><span class="show-for-sr">QuantEcon</span></a></li>
+                    <!-- <li class="btn__search">
                         <form action="{{ pathto('search') }}" method="get">
                             <input type="search" class="form-control" name="q" id="search-input" placeholder="{{ theme_search_bar_text }}" aria-label="{{ theme_search_bar_text }}" autocomplete="off">
                             <i data-feather="search"></i>
                         </form>
-                    </li>
+                    </li> -->
+                </ul>
+
+                <ul class="toolbar__links">
                     <li data-tippy-content="Fullscreen" class="btn__fullscreen"><i data-feather="maximize"></i></li>
                     <li data-tippy-content="Increase font size" class="btn__plus"><i data-feather="plus-circle"></i></li>
                     <li data-tippy-content="Decrease font size" class="btn__minus"><i data-feather="minus-circle"></i></li>
                     <li data-tippy-content="Change contrast" class="btn__contrast"><i data-feather="sunset"></i></li>
-                </ul>
-
-                <ul class="toolbar__links">
-                    <li data-tippy-content="Home"><a href="{{ master_doc }}.html"><i data-feather="home"></i></a></li>
                     {% if ipynb_source %}
                     <li data-tippy-content="Download Notebook"><a href="{{ pathto('_sources', 1) }}/{{ ipynb_source }}" download><i data-feather="download-cloud"></i></a></li>
                     {% endif %}

--- a/quantecon_book_theme/scss/quantecon-book-theme.scss
+++ b/quantecon_book_theme/scss/quantecon-book-theme.scss
@@ -72,7 +72,7 @@ html {
   clip: rect(0,0,0,0);
   }
 
-body { 
+body {
   font-size: 1rem;
   line-height: 1.5;
   font-weight: 400;

--- a/quantecon_book_theme/scss/quantecon-book-theme.scss
+++ b/quantecon_book_theme/scss/quantecon-book-theme.scss
@@ -64,7 +64,15 @@ html {
   }
 }
 
-body {
+.show-for-sr {
+  position: absolute!important;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  }
+
+body { 
   font-size: 1rem;
   line-height: 1.5;
   font-weight: 400;
@@ -268,7 +276,7 @@ tt {
     padding: 0;
     cursor: pointer;
     transition: all 0.2s ease-in-out;
-    opacity: 0.7;
+    opacity: 0.8;
     &:hover,
     &.btn-active {
       opacity: 1;
@@ -278,21 +286,30 @@ tt {
       color: $color-body;
     }
     &.btn__plus {
+      opacity: 0.5;
       .font-plus & {
         opacity: 1;
         transform: scale(1.1);
       }
     }
     &.btn__minus {
+      opacity: 0.5;
       .font-minus & {
         opacity: 1;
         transform: scale(1.1);
       }
     }
+    &.btn__contrast {
+      opacity: 0.5;
+      margin:0 2rem 0 0;
+    }
+    &.btn__fullscreen {
+      opacity: 0.5;
+    }
     &.btn__search {
       display: flex;
       align-items: center;
-      margin: 0 3rem 0 1rem;
+      //margin: 0 3rem 0 1rem;
       input {
         height: auto;
         display: inline-block;
@@ -306,6 +323,7 @@ tt {
         padding: 0.3rem 0.5rem;
         transition: all 0.2s linear;
         outline: 0;
+        display: none;
         &:focus {
           border-color: $color-body;
         }
@@ -319,6 +337,20 @@ tt {
         input {
           border-color: $color-body;
         }
+      }
+    }
+    &.btn__qelogo {
+      a {
+        display: block;
+        overflow: hidden;
+        height: 30px;
+        width: 105px;
+        background: url(https://assets.quantecon.org/img/menubar/qemb-logo.png) no-repeat left top;
+        background-size: 105px 30px;
+      }
+    }
+    &.btn__sidebar {
+      svg {
       }
     }
     svg {
@@ -451,18 +483,23 @@ tt {
 }
 
 .sidebar {
-  position: absolute;
+  //position: absolute;
   top: 0px;
   left: 0px;
   background-color: #efefef;
   padding: 2rem;
   margin: 0;
   border-right: 1px solid #ccc;
-  height: 100%;
+  //height: 100%;
   width: 250px;
   transform: translate3d(0px, 0px, 0px);
   visibility: visible;
   transition: all 0.5s ease 0s;
+
+  height: 100vh;
+  overflow-y: scroll;
+  position: fixed;
+  padding-top: 5rem;
   @media (max-width: 1340px) {
     box-shadow: 10px 10px 5px 9999px rgba(255,255,255,0.8);
     width: 300px;

--- a/tests/test_build/test_build_book.html
+++ b/tests/test_build/test_build_book.html
@@ -34,12 +34,5 @@
   </ul>
  </nav>
  <div class="sidebar__footer">
-  <p>
-   <img src="https://python-programming.quantecon.org/_static/img/qe-logo.png"/>
-  </p>
-  Theme by the
-  <a href="https://quantecon.org/">
-   QuantEcon
-  </a>
  </div>
 </div>


### PR DESCRIPTION
Discussed changes to toolbar and sidebar.

I am not sure where the `qe-menubar.js` script is being added along the line but this can now be removed.

The PR should adjust the theme as so:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/5886045/96367173-d23ed880-1197-11eb-9e6a-1524166e4fce.png">
