### PR TITLE
adjust codecov for now and open issue to improve

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,9 +2,9 @@ coverage:
   status:
     project:
       default:
-        target: 85%
+        target: 60%
         threshold: 0.5%
     patch:
       default:
-        target: 80%
+        target: 60%
         threshold: 0.5%


### PR DESCRIPTION
This sets codecov at `60%` and will raise an issue to make coverage improvements when becomes a priority