### PR TITLE
[NEW]: Repo url for source repos

### DIFF
--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -172,7 +172,7 @@
                     <li data-tippy-content="Download Notebook"><a href="{{ pathto('_sources', 1) }}/{{ ipynb_source }}" download><i data-feather="download-cloud"></i></a></li>
                     {% endif %}
                     <li data-tippy-content="Download PDF" onClick="window.print()"><i data-feather="file"></i></li>
-                    <li data-tippy-content="View Source"><a href="{{ pathto('_sources', 1) }}/{{ sourcename }}" download><i data-feather="github"></i></a></li>
+                    <li data-tippy-content="View Source"><a href="{{ theme_repo_url }}/{{ sourcename }}" download><i data-feather="github"></i></a></li>
                 </ul>
 
             </div>

--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -172,7 +172,7 @@
                     <li data-tippy-content="Download Notebook"><a href="{{ pathto('_sources', 1) }}/{{ ipynb_source }}" download><i data-feather="download-cloud"></i></a></li>
                     {% endif %}
                     <li data-tippy-content="Download PDF" onClick="window.print()"><i data-feather="file"></i></li>
-                    <li data-tippy-content="View Source"><a href="{{ theme_repo_url }}/{{ sourcename }}" download><i data-feather="github"></i></a></li>
+                    <li data-tippy-content="View Source"><a href="{{ theme_repository_url }}/{{ sourcename }}" download><i data-feather="github"></i></a></li>
                 </ul>
 
             </div>

--- a/quantecon_book_theme/theme.conf
+++ b/quantecon_book_theme/theme.conf
@@ -19,4 +19,4 @@ use_repository_button = False
 plugins_list = []
 header_organisation_url =
 header_organisation =
-repo_url =
+repository_url =

--- a/quantecon_book_theme/theme.conf
+++ b/quantecon_book_theme/theme.conf
@@ -19,3 +19,4 @@ use_repository_button = False
 plugins_list = []
 header_organisation_url =
 header_organisation =
+repo_url =


### PR DESCRIPTION
Just a simple implementation of specifying `github_source_url` for `view source` button.

fixes https://github.com/QuantEcon/lecture-python-programming.myst/issues/52 .
