### PR TITLE
HTML metadata

### DIFF
--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -2,23 +2,28 @@
 
 {% block extrahead %}
 
-<!-- Twitter tags -->
-<meta name="twitter:card" content="summary">
-<meta name="twitter:site" content="@quantecon">
-<meta name="twitter:title" content="Table of Contents">
-<meta name="twitter:description" content="This website presents a set of lectures on python programming for economics, designed and written by Thomas J. Sargent and John Stachurski.">
-<meta name="twitter:creator" content="@quantecon">
-<meta name="twitter:image" content="https://assets.quantecon.org/img/qe-twitter-logo.png">
+    <!-- HTML metadata -->
+    <meta name="author" content="{{ author | e }}">
+    <meta name="keywords" content="{{ keywords | e }}">
+    <meta name="description" content="{{ description | e }}">
 
-<!-- Opengraph tags -->
-<meta property="og:title" content="Table of Contents" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="https://python.quantecon.org/index_toc.html" />
-<meta property="og:image" content="https://assets.quantecon.org/img/qe-og-logo.png" />
-<meta property="og:description" content="This website presents a set of lectures on python programming for economics, designed and written by Thomas J. Sargent and John Stachurski." />
-<meta property="og:site_name" content="Python Programming for Economics and Finance" />
+    <!-- Twitter tags -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:site" content="@{{ twitter }}">
+    <meta name="twitter:title" content="{% if pagetitle %}{{ pagetitle | e }}{% else %}{{ title | e }}{% endif %}">
+    <meta name="twitter:description" content="{{ description | e }}">
+    <meta name="twitter:creator" content="@{{ twitter | e }}">
+    <meta name="twitter:image" content="{{ twitter_logo_url | e }}">
 
-<meta name="theme-color" content="#ffffff" />
+    <!-- Opengraph tags -->
+    <meta property="og:title" content="{% if pagetitle %}{{ pagetitle | e }}{% else %}{{ title | e }}{% endif %}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="{{ pageurl | e }}" />
+    <meta property="og:image" content="{{ og_logo_url }}" />
+    <meta property="og:description" content="{{ description | e }}" />
+    <meta property="og:site_name" content="{{ title | e }}" />
+
+    <meta name="theme-color" content="#ffffff" />
 
 {% endblock %}
 

--- a/tests/test_build/escaped_description.html
+++ b/tests/test_build/escaped_description.html
@@ -1,1 +1,6 @@
-<meta content='Page 1  Test content with &lt;a href="https://google.com"&gt;Some raw HTML&lt;/a&gt; to test.' property="og:description"/>
+<meta content="" property="og:description">
+ <meta content='&lt;span class="section-number"&gt;1. &lt;/span&gt;Page 1' property="og:site_name">
+  <meta content="#ffffff" name="theme-color">
+  </meta>
+ </meta>
+</meta>


### PR DESCRIPTION
This PR adds the same metadata present in the current lecture site to the theme layout file.

The required metadata variables have been added to the source repo:
https://github.com/QuantEcon/lecture-python-programming.myst/pull/67