### PR TITLE
👌 IMPROVE: Background style for code cells

### DIFF
--- a/quantecon_book_theme/scss/quantecon-book-theme.scss
+++ b/quantecon_book_theme/scss/quantecon-book-theme.scss
@@ -838,6 +838,16 @@ tt {
     visibility: visible;
   }
 
+  // Code blocks should have a margin, but code *cells* get margin from a parent
+  div.highlight {
+    background: none;
+    margin-bottom: 1em;
+  }
+
+  div.cell div.highlight {
+    margin-bottom: 0em;
+  }
+
   .cell .input,
   .cell .output {
     position: relative;


### PR DESCRIPTION
Added styling of `highlight` class for code-cells in the theme, in accordance with the discussion in this PR https://github.com/executablebooks/MyST-NB/pull/269 . 

This current PR basically removes the background styling of the `highlight` cell so that styles migrated from other packages like pygments do not affect it. 