### PR TITLE
🐛 FIX: Code-block 'Out' text

### DIFF
--- a/quantecon_book_theme/scss/_syntax.scss
+++ b/quantecon_book_theme/scss/_syntax.scss
@@ -21,11 +21,11 @@
     font-family: monospace, serif;
     font-weight: 400;
   }
-  .highlight-none .highlight:before {
-    content: 'Out';
-    color: #d84315;
-    top: 0rem;
-  }
+  // .highlight-none .highlight:before {
+  //   content: 'Out';
+  //   color: #d84315;
+  //   top: 0rem;
+  // }
   .highlight-none .highlight {
     background: #ffffff;
     border: 0;

--- a/quantecon_book_theme/scss/quantecon-book-theme.scss
+++ b/quantecon_book_theme/scss/quantecon-book-theme.scss
@@ -862,20 +862,20 @@ tt {
     width: 45px;
   }
 
-  .cell .output .prompt:before,
-  .cell .input .prompt:before {
-    visibility: visible;
-    position: absolute;
-    top: 0rem;
-    right: 0;
-    content: 'Out';
-    font-weight: bold;
-    font-size: 16px;
-    text-align: right;
-    color: #d84315;
-    font-family: monospace, serif;
-    font-weight: 400;
-  }
+  // .cell .output .prompt:before,
+  // .cell .input .prompt:before {
+  //   visibility: visible;
+  //   position: absolute;
+  //   top: 0rem;
+  //   right: 0;
+  //   content: 'Out';
+  //   font-weight: bold;
+  //   font-size: 16px;
+  //   text-align: right;
+  //   color: #d84315;
+  //   font-family: monospace, serif;
+  //   font-weight: 400;
+  // }
 
   .cell .input .prompt:before {
     content: 'In';

--- a/quantecon_book_theme/scss/quantecon-book-theme.scss
+++ b/quantecon_book_theme/scss/quantecon-book-theme.scss
@@ -838,6 +838,16 @@ tt {
     visibility: visible;
   }
 
+  // Code blocks should have a margin, but code *cells* get margin from a parent
+  div.highlight {
+    background: none;
+    margin-bottom: 1em;
+  }
+
+  div.cell div.highlight {
+    margin-bottom: 0em;
+  }
+
   .cell .input,
   .cell .output {
     position: relative;


### PR DESCRIPTION
At present we are commenting out the remnants of `Out` text for code-cells. 
Created a feature request for it with the ability to show execution count in code-cells. https://github.com/QuantEcon/quantecon-book-theme/issues/83

fixes https://github.com/QuantEcon/lecture-python.myst/issues/40