### PR TITLE
Add align center to figure class #80

### DIFF
--- a/quantecon_book_theme/scss/quantecon-book-theme.scss
+++ b/quantecon_book_theme/scss/quantecon-book-theme.scss
@@ -961,6 +961,16 @@ tt {
     font-size: 0.92rem;
   }
 
+  .figure {
+    text-align: center;
+    &.align-left {
+      text-align: left;
+    }
+    &.align-right {
+      text-align: right;
+    }
+  }
+
 }
 
 // Cell-specific controls


### PR DESCRIPTION
Adds an align center style to all `figure` elements. Adding `align-left` or `align-right` will override default behaviour.