### PR TITLE
FIX: Inline math collide

### DIFF
--- a/quantecon_book_theme/scss/quantecon-book-theme.scss
+++ b/quantecon_book_theme/scss/quantecon-book-theme.scss
@@ -939,10 +939,6 @@ tt {
     color: #0072bc;
   }
 
-  span.math {
-    font-size: 0.92em;
-  }
-
   div.math {
     margin: 2rem 0;
   }
@@ -955,10 +951,6 @@ tt {
 
   a .MathJax {
     color: #0072bc;
-  }
-
-  span.MathJax {
-    font-size: 0.92rem;
   }
 
   .figure {

--- a/quantecon_book_theme/static/scripts.js
+++ b/quantecon_book_theme/static/scripts.js
@@ -181,6 +181,9 @@ MathJax.Hub.Config({
         ],
         processEscapes: true,
     },
+    CommonHTML: {
+        scale: 92
+    },
 });
 
 /* Collapsed code block */


### PR DESCRIPTION
This PR changes the MathJax font size setting. Rather than using CSS we now set relative size (92%) using JS in the MathJax config. This is to hopefully fix the Safari rendering issue, where the element size was smaller than the rendered equation - causing overlaps (https://github.com/QuantEcon/lecture-python.myst/issues/117).