### PR TITLE
🐛 FIX: fixing black version to prevent pre-commit failure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     - id: flake8
 
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "click",
         "setuptools",
         "libsass",
-        "pydata-sphinx-theme~=0.4.0",
+        "pydata-sphinx-theme~=0.4.1",
         "beautifulsoup4",
     ],
     extras_require={
@@ -47,11 +47,12 @@ setup(
             "sphinx-thebe",
         ],
         "testing": [
+            "myst_nb~=0.11.1",
             "coverage",
             "pytest~=6.0.1",
             "pytest-cov",
             "beautifulsoup4",
-            "pytest-regressions",
+            "pytest-regressions~=2.0.1",
         ],
     },
     entry_points={

--- a/tests/test_build/test_build_book.html
+++ b/tests/test_build/test_build_book.html
@@ -3,7 +3,7 @@
   Contents
  </div>
  <nav aria-label="Main navigation" class="sidebar__nav" id="sidebar-nav">
-  <p class="caption">
+  <p>
    <span class="caption-text">
     My caption
    </span>


### PR DESCRIPTION
In pre-commit-config.yaml, the rev of black is `stable` :

```
- repo: https://github.com/psf/black
    rev: stable
    hooks:
    - id: black
```

which is throwing the following error:
<img width="1360" alt="Screen Shot 2021-04-06 at 8 07 47 pm" src="https://user-images.githubusercontent.com/6542997/113720135-ad342700-9731-11eb-8e03-4d2e41a32749.png">

have changed the rev to the latest version:

```
- repo: https://github.com/psf/black
    rev: 20.8b1
    hooks:
    - id: black
```