### PR TITLE
♻️ REFACTOR: Pydata-sphinx-theme~=0.6.0 adaption

### DIFF
--- a/quantecon_book_theme/__init__.py
+++ b/quantecon_book_theme/__init__.py
@@ -71,6 +71,7 @@ def add_to_context(app, pagename, templatename, context, doctree):
         include_item_names=False,
         with_home_page=False,
         prev_section_numbers=None,
+        kind="sidebar",
     ):
         # Config stuff
         config = app.env.config

--- a/quantecon_book_theme/__init__.py
+++ b/quantecon_book_theme/__init__.py
@@ -80,7 +80,7 @@ def add_to_context(app, pagename, templatename, context, doctree):
         # Grab the raw toctree object and structure it so we can manipulate it
         toc_sphinx = context["generate_nav_html"](
             startdepth=level - 1,
-            maxdepth=-1,
+            maxdepth=level + 1,
             kind="sidebar",
             collapse=False,
             titles_only=True,

--- a/quantecon_book_theme/__init__.py
+++ b/quantecon_book_theme/__init__.py
@@ -10,7 +10,7 @@ from sass import compile as sass_compile
 
 from .launch import add_hub_urls
 
-__version__ = "0.1.5b1"
+__version__ = "0.1.5"
 """quantecon-book-theme version"""
 
 SPHINX_LOGGER = logging.getLogger(__name__)
@@ -66,12 +66,11 @@ def find_url_relative_to_root(pagename, relative_page, path_docs_source):
 
 
 def add_to_context(app, pagename, templatename, context, doctree):
-    def generate_nav_html(
+    def sbt_generate_nav_html(
         level=1,
         include_item_names=False,
         with_home_page=False,
         prev_section_numbers=None,
-        kind="sidebar",
     ):
         # Config stuff
         config = app.env.config
@@ -79,8 +78,13 @@ def add_to_context(app, pagename, templatename, context, doctree):
             with_home_page = with_home_page.lower() == "true"
 
         # Grab the raw toctree object and structure it so we can manipulate it
-        toc_sphinx = context["toctree"](
-            maxdepth=-1, collapse=False, titles_only=True, includehidden=True
+        toc_sphinx = context["generate_nav_html"](
+            startdepth=level - 1,
+            maxdepth=-1,
+            kind="sidebar",
+            collapse=False,
+            titles_only=True,
+            includehidden=True,
         )
         toctree = bs(toc_sphinx, "html.parser")
 
@@ -137,7 +141,7 @@ def add_to_context(app, pagename, templatename, context, doctree):
 
         return toctree.prettify()
 
-    context["generate_nav_html"] = generate_nav_html
+    context["sbt_generate_nav_html"] = sbt_generate_nav_html
 
     def generate_toc_html():
         """Return the within-page TOC links in HTML."""

--- a/quantecon_book_theme/__init__.py
+++ b/quantecon_book_theme/__init__.py
@@ -10,7 +10,7 @@ from sass import compile as sass_compile
 
 from .launch import add_hub_urls
 
-__version__ = "0.1.5"
+__version__ = "0.1.5b1"
 """quantecon-book-theme version"""
 
 SPHINX_LOGGER = logging.getLogger(__name__)

--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -156,7 +156,7 @@
                 </div>
 
                 <nav class="sidebar__nav" id="sidebar-nav" aria-label="Main navigation">
-                    {{ generate_nav_html(include_item_names=True, with_home_page=theme_home_page_in_toc, kind="sidebar") }}
+                    {{ sbt_generate_nav_html(include_item_names=False, with_home_page=theme_home_page_in_toc) }}
                 </nav>
 
                 <div class="sidebar__footer">

--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -51,7 +51,7 @@
 
                     <div class="inner">
 
-                        {% set page_toc = get_page_toc_object() %}
+                        {% set page_toc = generate_toc_html() %}
 
                         {%- if page_toc | length >= 1 %}
                         <div class="page__toc-header">

--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -156,7 +156,7 @@
                 </div>
 
                 <nav class="sidebar__nav" id="sidebar-nav" aria-label="Main navigation">
-                    {{ generate_nav_html(include_item_names=True, with_home_page=theme_home_page_in_toc) }}
+                    {{ generate_nav_html(include_item_names=True, with_home_page=theme_home_page_in_toc, kind="sidebar") }}
                 </nav>
 
                 <div class="sidebar__footer">

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "click",
         "setuptools",
         "libsass",
-        "pydata-sphinx-theme~=0.4.1",
+        "pydata-sphinx-theme~=0.6.1",
         "beautifulsoup4",
     ],
     extras_require={

--- a/tests/test_build/test_build_book.html
+++ b/tests/test_build/test_build_book.html
@@ -8,7 +8,7 @@
     My caption
    </span>
   </p>
-  <ul class="nav sidenav_l1">
+  <ul class="nav bd-sidenav nav sidenav_l1">
    <li class="toctree-l1">
     <a class="reference internal" href="page1.html">
      1. Page 1
@@ -19,10 +19,15 @@
      2. Page 2
     </a>
    </li>
-   <li class="toctree-l1">
+   <li class="toctree-l1 has-children">
     <a class="reference internal" href="section1/index.html">
      3. Section 1 index
     </a>
+    <input class="toctree-checkbox" id="toctree-checkbox-1" name="toctree-checkbox-1" type="checkbox"/>
+    <label for="toctree-checkbox-1">
+     <i class="fas fa-chevron-down">
+     </i>
+    </label>
    </li>
    <li class="toctree-l1">
     <a class="reference external" href="https://google.com">


### PR DESCRIPTION
Mostly adapting `generate_nav_html ` function, which has changed in `pydata-sphinx-theme~=0.6.0`. SInce, this version is now pinned by `jb`, it should be adapted in `quantecon-book-theme` . 