### PR TITLE
🐛 FIX: Right side navbar fix

### DIFF
--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -61,20 +61,7 @@
 
 
                         <nav id="bd-toc-nav" class="page__toc-nav">
-
-                            <ul class="nav section-nav flex-column">
-                                {% for item in page_toc recursive %}
-                                <li class="nav-item toc-entry toc-h{{ loop.depth + 1 }}">
-                                    <a href="{{ item.url }}" class="nav-link">{{ item.title }}</a>
-                                    {%- if item.children -%}
-                                    <ul class="nav section-nav flex-column">
-                                        {{ loop(item.children) }}
-                                    </ul>
-                                    {%- endif %}
-                                </li>
-                                {% endfor %}
-                            </ul>
-
+                            {{ page_toc }}
                             <p class="logo">
                                 {% if logo %}
                                     {% if theme_header_organisation_url %}


### PR DESCRIPTION
RIght navbar went missing with the `quantecon-book-theme` 0.1.6 release, this PR fixes it. 
The default navbar HTML inherited from `pydata-sphinx-theme` also has numbering of the sections included. (when numbered:true)

<img width="333" alt="Screen Shot 2021-05-03 at 10 27 45 am" src="https://user-images.githubusercontent.com/6542997/116832960-36882d80-abfa-11eb-891e-8df7d181a935.png">

fixes https://github.com/QuantEcon/quantecon-book-theme/issues/110