### PR TITLE
👌 IMPROVE: Showing download dropdown when book pdf is present 

### DIFF
--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -186,7 +186,11 @@
                         <li class="settings-button" id="settingsButton"><i data-feather="settings"></i></li>
                     {%- endif %}
                     {%- endif %}
-                    <li class="download-pdf" id="downloadButton"><i data-feather="file"></i></li>
+                    {%- if pdf_book_path %}
+                        <li class="download-pdf" id="downloadButton"><i data-feather="file"></i></li>
+                    {%- else %}
+                        <li data-tippy-content="Download PDF" onClick="window.print()"><i data-feather="file"></i></li>
+                    {%- endif %}
                     <li data-tippy-content="View Source"><a target="_blank" href="{{ theme_repository_url }}{{github_sourcefolder}}/{{ sourcename }}" download><i data-feather="github"></i></a></li>
                 </ul>
 
@@ -198,11 +202,9 @@
                 <li class="download-pdf-book" onClick="window.print()">
                     <p>Lecture (PDF)</p>
                 </li>
-                {% if pdf_book_path %}
                 <li class="download-pdf-file">
                     <a href="{{ pdf_book_path }}" download><p style="color: white;">Book (PDF)</p></a>
                 </li>
-                {%- endif %}
             </ul>
         </div>
         <div id="settingsModal" style="display: none;">


### PR DESCRIPTION
The below dropdown is shown only if book pdf is accessible 

<img width="240" alt="Screen Shot 2021-05-06 at 10 04 35 am" src="https://user-images.githubusercontent.com/6542997/117224091-78abac00-ae52-11eb-93f2-db45e90c2d43.png">

else clicking on the icon, directly goes to downloading lecture pdf.