### PR TITLE
🐛 FIX: Adding google analytics id

### DIFF
--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -314,6 +314,9 @@
         </div>
 
     </div> <!-- .wrapper-->
+    {%- block scripts_end %}
+    {{ generate_google_analytics_script(id=theme_google_analytics_id) }}
+    {%- endblock %}
 {%- endblock %}
 
 {% block docs_toc %}


### PR DESCRIPTION
The google analytics code feature is re-added to the layout.

The config variable to specify google analytics is the same as before:

```
html: 
  google_analytics_id: <analytics id>
```

or

```
sphinx:
  config:
     html_theme_options:
        google_analytics_id: <analytics id>
```

fixes https://github.com/QuantEcon/quantecon-book-theme/issues/134