### PR TITLE
🐛 FIX: Configuring mathjax before the script that loads mathjax

### DIFF
--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -4,6 +4,25 @@
     <script src="https://unpkg.com/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
     <script src="https://unpkg.com/tippy.js@6.3.1/dist/tippy-bundle.umd.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
+    <script>
+        MathJax = {
+          loader: {load: ['[tex]/boldsymbol']},
+          tex: {
+            packages: {'[+]': ['boldsymbol']},
+            inlineMath: [['$', '$'], ['\\(', '\\)']],
+            processEscapes: true,
+            macros: {
+                "argmax" : "arg\\,max",
+                "argmin" : "arg\\,min"
+            }
+          },
+          svg: {
+            fontCache: 'global',
+            scale: 0.92,
+            displayAlign: "center",
+          },
+        };
+    </script>
     {{ super() }}
 {% endblock %}
 {% block extrahead %}

--- a/quantecon_book_theme/static/quantecon-book-theme.f77f720613e25edc6a92ce4459c6ecdc.js
+++ b/quantecon_book_theme/static/quantecon-book-theme.f77f720613e25edc6a92ce4459c6ecdc.js
@@ -23,4 +23,4 @@ let urlpath=document.getElementById("launcher-private-input").dataset.urlpath
 const repoPrefix="/jupyter/hub/user-redirect/git-pull?repo="+repo+"&urlpath="+urlpath;url=private+repoPrefix+pagename+".ipynb";launchButton.getElementsByTagName("a")[0].setAttribute("href",url)}else{let url=document.getElementById("launcher-public-input").value
 let launchButton=document.getElementById("launchButton")
 launchButton.getElementsByTagName("a")[0].setAttribute("href",url)}}
-tippy('[data-tippy-content]',{touch:false,});feather.replace();window.MathJax={loader:{load:['[tex]/boldsymbol']},tex:{packages:{'[+]':['boldsymbol']}},tex:{inlineMath:[['$','$'],['\\(','\\)'],],processEscapes:true},chtml:{scale:0.92,displayAlign:"center"},svg:{scale:0.92,displayAlign:"center",},options:{menuOptions:{settings:{renderer:'SVG'}}},};})
+tippy('[data-tippy-content]',{touch:false,});feather.replace();})

--- a/src/js/quantecon-book-theme.js
+++ b/src/js/quantecon-book-theme.js
@@ -260,31 +260,4 @@ $(window).on('load', () => {
     });
     feather.replace();
 
-    window.MathJax = {
-        loader: {load: ['[tex]/boldsymbol']},
-        tex: {packages: {'[+]': ['boldsymbol']}},
-        tex: {
-            inlineMath: [
-                ['$', '$'],
-                ['\\(', '\\)'],
-            ],
-            processEscapes: true
-        },
-        chtml: {
-            scale: 0.92,
-            displayAlign: "center"
-        },
-        svg: {
-            scale: 0.92,
-            displayAlign: "center",
-        },
-        options: {
-            menuOptions: {
-                settings: {
-                    renderer: 'SVG'
-                }
-            }
-        },
-    };
-
 })


### PR DESCRIPTION
Added hardcoded mathjax inline script, before mathjax itself loads, to make the config work, according to: http://docs.mathjax.org/en/latest/web/configuration.html#configuration-using-an-in-line-script

The present config option to configure mathjax in `_config.yml` wont work with mathjaxv3 as mentioned in the following comment. https://github.com/executablebooks/jupyter-book/blob/master/docs/_config.yml#L66

Once, we start using sphinx v4, we can use `mathjax3_config` to set all the macros in the configuration file https://sphinx--9094.org.readthedocs.build/en/9094/usage/extensions/math.html#confval-mathjax3_config .

But, for now, we will have to make with hardcoded configuration in the theme.  

fixes https://github.com/QuantEcon/quantecon-book-theme/issues/135