### PR TITLE
👌 IMPROVE: Checking mathjax version and functioning accordingly

### DIFF
--- a/quantecon_book_theme/__init__.py
+++ b/quantecon_book_theme/__init__.py
@@ -215,6 +215,11 @@ def add_to_context(app, pagename, templatename, context, doctree):
             (app.config.html_baseurl.rstrip("/"), "_static/" + context["logo"])
         )
 
+    # Check mathjax version and set it in a variable
+    if app.config["mathjax_path"] and "@3" in app.config["mathjax_path"]:
+        context["mathjax_version"] = 3
+    else:
+        context["mathjax_version"] = 2
     # Add HTML context variables that the pydata theme uses that we configure elsewhere
     # For some reason the source_suffix sometimes isn't there even when doctree is
     if doctree and context.get("page_source_suffix"):

--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -4,41 +4,43 @@
     <script src="https://unpkg.com/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
     <script src="https://unpkg.com/tippy.js@6.3.1/dist/tippy-bundle.umd.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
-    <script>
-        MathJax = {
-          loader: {load: ['[tex]/boldsymbol']},
-          tex: {
-            packages: {'[+]': ['boldsymbol']},
-            inlineMath: [['$', '$'], ['\\(', '\\)']],
-            processEscapes: true,
-            macros: {
-                "argmax" : "arg\\,max",
-                "argmin" : "arg\\,min",
-                "col"    : "col",
-                "Span"   :  "span",
-                "epsilon": "\\varepsilon",
-                "EE": "\\mathbb{E}",
-                "PP": "\\mathbb{P}",
-                "RR": "\\mathbb{R}",
-                "NN": "\\mathbb{N}",
-                "ZZ": "\\mathbb{Z}",
-                "aA": "\\mathcal{A}",
-                "bB": "\\mathcal{B}",
-                "cC": "\\mathcal{C}",
-                "dD": "\\mathcal{D}",
-                "eE": "\\mathcal{E}",
-                "fF": "\\mathcal{F}",
-                "gG": "\\mathcal{G}",
-                "hH": "\\mathcal{H}",
-            }
-          },
-          svg: {
-            fontCache: 'global',
-            scale: 0.92,
-            displayAlign: "center",
-          },
-        };
-    </script>
+    {% if mathjax_version == 3 %}
+        <script>
+            MathJax = {
+            loader: {load: ['[tex]/boldsymbol']},
+            tex: {
+                packages: {'[+]': ['boldsymbol']},
+                inlineMath: [['$', '$'], ['\\(', '\\)']],
+                processEscapes: true,
+                macros: {
+                    "argmax" : "arg\\,max",
+                    "argmin" : "arg\\,min",
+                    "col"    : "col",
+                    "Span"   :  "span",
+                    "epsilon": "\\varepsilon",
+                    "EE": "\\mathbb{E}",
+                    "PP": "\\mathbb{P}",
+                    "RR": "\\mathbb{R}",
+                    "NN": "\\mathbb{N}",
+                    "ZZ": "\\mathbb{Z}",
+                    "aA": "\\mathcal{A}",
+                    "bB": "\\mathcal{B}",
+                    "cC": "\\mathcal{C}",
+                    "dD": "\\mathcal{D}",
+                    "eE": "\\mathcal{E}",
+                    "fF": "\\mathcal{F}",
+                    "gG": "\\mathcal{G}",
+                    "hH": "\\mathcal{H}",
+                }
+            },
+            svg: {
+                fontCache: 'global',
+                scale: 0.92,
+                displayAlign: "center",
+            },
+            };
+        </script>
+    {% endif %}
     {{ super() }}
 {% endblock %}
 {% block extrahead %}


### PR DESCRIPTION
Decoding mathjax version based on `mathjax_path` config variable, and using the hardcoded mathjax configuration only for version 3. Which will be removed at a later stage https://github.com/QuantEcon/quantecon-book-theme/issues/138

