### PR TITLE
👌 IMPROVE: Conditional links for download notebooks

### DIFF
--- a/quantecon_book_theme/__init__.py
+++ b/quantecon_book_theme/__init__.py
@@ -191,6 +191,10 @@ def add_to_context(app, pagename, templatename, context, doctree):
     if os.path.isdir(app.outdir + "/_pdf"):
         context["pdf_book_path"] = "_pdf/" + context["pdf_book_name"] + ".pdf"
 
+    # check if notebook folder is present
+    if os.path.isdir(app.outdir + "/_notebooks"):
+        context["notebook_path"] = "_notebooks/" + context["pagename"] + ".ipynb"
+
     # Update the page title because HTML makes it into the page title occasionally
     if pagename in app.env.titles:
         title = app.env.titles[pagename]

--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -221,7 +221,9 @@
                     <li data-tippy-content="Increase font size" class="btn__plus"><i data-feather="plus-circle"></i></li>
                     <li data-tippy-content="Decrease font size" class="btn__minus"><i data-feather="minus-circle"></i></li>
                     <li data-tippy-content="Change contrast" class="btn__contrast"><i data-feather="sunset"></i></li>
-                    <li data-tippy-content="Download Notebook"><a href="/_notebooks/{{ pagename }}.ipynb" download><i data-feather="download-cloud"></i></a></li>
+                    {%- if notebook_path %}
+                    <li data-tippy-content="Download Notebook"><a href="{{ notebook_path }}" download><i data-feather="download-cloud"></i></a></li>
+                    {%- endif %}
                     {%- if theme_nb_repository_url %}
                     <li class="settings-button" id="settingsButton"><div data-tippy-content="Launch Notebook"><i data-feather="play-circle"></i></div></li>
                     {%- endif %}


### PR DESCRIPTION
Show download notebook links only if `_notebooks` folder is present in HTML output directory.

fixes https://github.com/QuantEcon/quantecon-book-theme/issues/156