### PR TITLE
👌 IMPROVE: Adding textmacros as a Mathjax extension

### DIFF
--- a/quantecon_book_theme/layout.html
+++ b/quantecon_book_theme/layout.html
@@ -7,9 +7,9 @@
     {% if mathjax_version == 3 %}
         <script>
             MathJax = {
-            loader: {load: ['[tex]/boldsymbol']},
+            loader: {load: ['[tex]/boldsymbol', '[tex]/textmacros']},
             tex: {
-                packages: {'[+]': ['boldsymbol']},
+                packages: {'[+]': ['boldsymbol', 'textmacros']},
                 inlineMath: [['$', '$'], ['\\(', '\\)']],
                 processEscapes: true,
                 macros: {


### PR DESCRIPTION
This is a new package in MathJax v3 which adds the ability to process some text-mode macros within `\text{}` and other macros that produce text-mode material.

http://docs.mathjax.org/en/latest/input/tex/extensions/textmacros.html#tex-textmacros