### PR TITLE
🐛 FIX: Using `nb_branch` for launch button url links

### DIFF
--- a/docs/launch.md
+++ b/docs/launch.md
@@ -11,7 +11,7 @@ documentation's repository url:
 html_theme_options = {
     ...
     "repository_url": "https://github.com/{your-docs-url}",
-    "repository_branch": "{your-branch}",
+    "nb_branch": "{your-branch}",
     "path_to_docs": "{path-relative-to-site-root},
     ...
 }

--- a/quantecon_book_theme/launch.py
+++ b/quantecon_book_theme/launch.py
@@ -52,8 +52,6 @@ def add_hub_urls(
             # Skip the rest because the repo_url isn't right
             return
 
-        branch = _get_branch(config_theme)
-
         # Construct the extra URL parts (app and relative path)
         notebook_interface_prefixes = {"classic": "tree", "jupyterlab": "lab/tree"}
         notebook_interface = launch_buttons.get("notebook_interface", "classic")
@@ -180,7 +178,7 @@ def _is_notebook(app, pagename):
 
 
 def _get_branch(config_theme):
-    branch = config_theme.get("repository_branch")
+    branch = config_theme.get("nb_branch")
     if not branch:
         branch = "master"
     return branch


### PR DESCRIPTION
It was using the variable `repository_branch ` earlier, which was a mistake. As `repository_branch ` is meant to hold the value of the source file repository branch name. 