### PR TITLE
FIX: Dark theme styling fixes

### DIFF
--- a/src/quantecon_book_theme/assets/styles/index.scss
+++ b/src/quantecon_book_theme/assets/styles/index.scss
@@ -167,7 +167,8 @@ body {
         color: #fff !important;
       }
       .image-reference img,
-      figure img {
+      figure img,
+      .cell_output img {
         filter: invert(100%) hue-rotate(-180deg) !important;
         -ms-filter: invert(100%) !important;
         -webkit-filter: invert(100%) hue-rotate(-180deg) !important;
@@ -252,6 +253,18 @@ body {
 
     mjx-math mjx-mstyle {
       color: white !important;
+    }
+
+    #settingsModal {
+      span {
+        color: white;
+      }
+    }
+
+    .cell_output .output.text_plain,
+    .cell_output .output.stream,
+    .cell_output .output.stderr {
+      border: 0rem;
     }
   }
 }

--- a/src/quantecon_book_theme/assets/styles/index.scss
+++ b/src/quantecon_book_theme/assets/styles/index.scss
@@ -166,7 +166,8 @@ body {
       .MathJax {
         color: #fff !important;
       }
-      .image-reference img {
+      .image-reference img,
+      figure img {
         filter: invert(100%) hue-rotate(-180deg) !important;
         -ms-filter: invert(100%) !important;
         -webkit-filter: invert(100%) hue-rotate(-180deg) !important;
@@ -236,6 +237,21 @@ body {
     .qe-toolbar__inner > ul > li.btn__search input {
       background-color: #333;
       color: #fff;
+    }
+
+    tbody tr:nth-child(even) {
+      color: white;
+    }
+    thead tr th {
+      color: white;
+    }
+
+    .highlight .nn {
+      color: white;
+    }
+
+    mjx-math mjx-mstyle {
+      color: white !important;
     }
   }
 }


### PR DESCRIPTION
fixes #227 

The screenshot of fixes are (ordering based on issue #227 ):

1) 
<img width="925" alt="Screen Shot 2023-10-05 at 3 35 07 pm" src="https://github.com/QuantEcon/quantecon-book-theme/assets/6542997/5254607c-c4e1-45cf-a783-582f6a5a5dc4">


2) 
<img width="830" alt="Screen Shot 2023-10-05 at 4 05 29 pm" src="https://github.com/QuantEcon/quantecon-book-theme/assets/6542997/69f10407-3a1c-46c0-b141-ead7d107b774">


3)  I feel the images look better this way in dark mode. If the background is white, its too bright and defeats the purpose of dark-theme. What do you think @mmcky @HumphreyYang 
<img width="852" alt="Screen Shot 2023-10-05 at 4 05 54 pm" src="https://github.com/QuantEcon/quantecon-book-theme/assets/6542997/381865e1-2b71-4611-b3e7-3106b91a93b0">


4) 
<img width="844" alt="Screen Shot 2023-10-05 at 4 06 13 pm" src="https://github.com/QuantEcon/quantecon-book-theme/assets/6542997/ecbab023-8f6f-45d3-bbbc-e86387274e71">

5) 
<img width="848" alt="Screen Shot 2023-10-05 at 4 06 41 pm" src="https://github.com/QuantEcon/quantecon-book-theme/assets/6542997/1da64583-8b10-4744-9723-086e47bad288">

cc: @HumphreyYang  @mmcky 