### PR TITLE
ENH: Adding logo image for dark mode

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,39 +11,55 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: 3.11
     - uses: pre-commit/action@v3.0.0
 
   tests:
-    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.9, "3.10"]
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11"]
+        # Only test the latest major release of Sphinx because otherwise we need to
+        # keep multiple versions of regression tests on file and this creates lots of
+        # noise in the tests.
+        sphinx: ["~=5.0"]
+        include:
+        - os: windows-latest
+          python-version: 3.x
+          # Windows pulling in dependencies fails
+          experimental: true
+        - os: macos-latest
+          python-version: 3.x
+    runs-on: ${{ matrix.os }}
+
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }} and Sphinx ${{ matrix.sphinx }}
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: "pip"
         cache-dependency-path: "pyproject.toml"
 
-    - name: Install dependencies
+    - name: Install dependencies with Sphinx ${{ matrix.sphinx }}
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e .[test]
+        python -m pip install --upgrade "sphinx${{matrix.sphinx}}" -e .[test] --pre
+
     - name: Run pytest
       run: >
         pytest --durations=10 --cov=quantecon_book_theme --cov-report=xml --cov-report=term-missing
 
     - name: Upload to Codecov
-      if: github.repository == 'QuantEcon/quantecon-book-theme'
-      uses: codecov/codecov-action@v3.1.0
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9 && github.repository == 'QuantEcon/quantecon-book-theme' && github.event_name == 'pull_request'
+      uses: codecov/codecov-action@v3.1.4
       with:
-        name: ebp-qbt-pytests-${{ matrix.python-version}}
+        name: ebp-qbt-pytests-py3.7
         flags: pytests
         file: ./coverage.xml
         fail_ci_if_error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,6 @@ jobs:
     - uses: pre-commit/action@v3.0.0
 
   tests:
-    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
@@ -29,10 +28,6 @@ jobs:
         # noise in the tests.
         sphinx: ["~=5.0"]
         include:
-        - os: windows-latest
-          python-version: 3.x
-          # Windows pulling in dependencies fails
-          experimental: true
         - os: macos-latest
           python-version: 3.x
     runs-on: ${{ matrix.os }}

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -114,3 +114,18 @@ html_theme_options = {
     ...
 }
 ```
+
+## Add a dark mode version of your logo
+
+To optimize your branding for dark mode, consider creating a dedicated dark mode variant of your logo.
+Then, configure the theme settings to display this variant when dark mode is active, using the following configuration:
+
+```python
+html_theme_options = {
+    ...
+    "dark_logo": "name-of-dark-logo-image"
+    ...
+}
+```
+
+The image is expected to be in the `_static` folder of your source repository.

--- a/src/quantecon_book_theme/assets/scripts/index.js
+++ b/src/quantecon_book_theme/assets/scripts/index.js
@@ -56,6 +56,8 @@ document.addEventListener("DOMContentLoaded", function () {
     $head = $("head"),
     $body = $("body"),
     $sidebar = $(".qe-sidebar"),
+    $lighLogo = $(".logo-img"),
+    $darkLogo = $(".dark-logo-img"),
     $sidebarToggle = $(".btn__sidebar");
 
   // Toolbar contrast toggle
@@ -83,6 +85,9 @@ document.addEventListener("DOMContentLoaded", function () {
       $(this).addClass("btn-active");
       localStorage.setContrast = 1;
       $body.addClass("dark-theme");
+      if (!$darkLogo.length) {
+        $lighLogo.css("display", "block");
+      }
     }
   });
 

--- a/src/quantecon_book_theme/assets/styles/index.scss
+++ b/src/quantecon_book_theme/assets/styles/index.scss
@@ -99,6 +99,14 @@ body {
     max-width: 100%;
   }
 
+  .logo-img {
+    display: block;
+  }
+
+  .dark-logo-img {
+    display: none;
+  }
+
   &.dark-theme {
     background: #222;
     color: #fff;
@@ -127,6 +135,14 @@ body {
     .maths,
     .math {
       color: #fff !important;
+    }
+
+    .logo-img {
+      display: none;
+    }
+
+    .dark-logo-img {
+      display: block;
     }
 
     .highlight {

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
@@ -106,7 +106,10 @@
                             <p class="logo">
                                 {% if logo %}
                                     {% if theme_header_organisation_url %}
-                                    <a href={{theme_header_organisation_url}}><img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="logo"></a>
+                                    <a href={{theme_header_organisation_url}}><img src="{{ pathto('_static/' + logo, 1) }}" class="logo logo-img" alt="logo"></a>
+                                    {% if theme_dark_logo %}
+                                    <a href={{theme_header_organisation_url}}><img src="{{ pathto('_static/' + theme_dark_logo, 1) }}" class="dark-logo-img" alt="logo"></a>
+                                    {% endif %}
                                     {% else %}
                                     <a href="{{ master_url }}"><img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="logo"></a>
                                     {% endif %}

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/theme.conf
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/theme.conf
@@ -28,3 +28,4 @@ twitter =
 twitter_logo_url =
 og_logo_url =
 persistent_sidebar = False
+dark_logo =

--- a/tests/sites/base/conf.py
+++ b/tests/sites/base/conf.py
@@ -23,6 +23,7 @@ html_theme_options = {
     "path_to_docs": "TESTPATH",
     "repository_url": "https://github.com/executablebooks/sphinx-book-theme",
     "nb_repository_url": "https://github.com/executablebooks/sphinx-book-theme",
+    "navigation_with_keys": True,
     # "repository_branch": "master",  # Not using this, should default to master
     "launch_buttons": {
         "binderhub_url": "https://mybinder.org",


### PR DESCRIPTION
This PR adds the ability to specify a dark-mode version of your logo. 
To use a separate logo image for dark mode, simply set it in configuration using the following setting:
```
html_theme_options:
    dark_logo: logo-image-dark-mode
```

The image is expected to be in the `_static` folder of your source repository