### PR TITLE
Adding author names in title of the main page

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -102,6 +102,22 @@ html_theme_options = {
 }
 ```
 
+## Add authors to your documentation
+
+If you'd like to add a list of authors to your documentation, you can do so with the following configuration:
+
+```python
+html_theme_options = {
+    ...
+    "authors": [
+        {"name": "author1", "url": "bio-link1"},
+        {"name": "author2", "url": "bio-link2"},
+    ]
+}
+```
+
+Authors with there bio links will be displayed just below the title of the page.
+
 ## Use plugins to add/extend features
 
 If you want some extra features in your documentation website or modify an existing one, you can add a list of plugins

--- a/src/quantecon_book_theme/assets/scripts/index.js
+++ b/src/quantecon_book_theme/assets/scripts/index.js
@@ -401,8 +401,9 @@ document.addEventListener("DOMContentLoaded", function () {
     //check if there are authors
     const isAuthor =
       authors &&
-      authors.querySelectorAll("a").length &&
-      authors.querySelectorAll("a")[0].innerText !== "";
+      ((authors.querySelectorAll("a").length &&
+        authors.querySelectorAll("a")[0].innerText !== "") ||
+        authors.innerText !== "");
     if (isAuthor) {
       newParagraph.innerHTML = authors.innerHTML;
     }

--- a/src/quantecon_book_theme/assets/scripts/index.js
+++ b/src/quantecon_book_theme/assets/scripts/index.js
@@ -376,17 +376,34 @@ document.addEventListener("DOMContentLoaded", function () {
     );
   })();
 
+  /**
+   * Add authors to the heading of toc page
+   */
   (function () {
     const authors = document.getElementsByClassName(
       "qe-page__header-authors",
-    )[0].innerText;
-    // adding authors to the page
-    if (authors) {
-      const h1a = document.querySelector("h1 a");
-      const newParagraph = document.createElement("p");
-      newParagraph.textContent = authors;
-      h1a.insertAdjacentElement("afterend", newParagraph);
+    )[0];
+
+    const h1 = document.querySelector(".main-index h1");
+
+    // check if its the main toc page
+    if (!h1) {
+      return;
     }
+    // creating a p tag for styling and author links
+    const newParagraph = document.createElement("p");
+    newParagraph.setAttribute("id", "qe-page-author-links");
+
+    //check if there are authors
+    const isAuthor =
+      authors &&
+      authors.querySelectorAll("a").length &&
+      authors.querySelectorAll("a")[0].innerText !== "";
+    if (isAuthor) {
+      newParagraph.innerHTML = authors.innerHTML;
+    }
+    // insert p tag after h1, even if no authors for styling
+    h1.insertAdjacentElement("afterend", newParagraph);
   })();
   // Tooltips
   tippy("[data-tippy-content]", {

--- a/src/quantecon_book_theme/assets/scripts/index.js
+++ b/src/quantecon_book_theme/assets/scripts/index.js
@@ -376,6 +376,18 @@ document.addEventListener("DOMContentLoaded", function () {
     );
   })();
 
+  (function () {
+    const authors = document.getElementsByClassName(
+      "qe-page__header-authors",
+    )[0].innerText;
+    // adding authors to the page
+    if (authors) {
+      const h1a = document.querySelector("h1 a");
+      const newParagraph = document.createElement("p");
+      newParagraph.textContent = authors;
+      h1a.insertAdjacentElement("afterend", newParagraph);
+    }
+  })();
   // Tooltips
   tippy("[data-tippy-content]", {
     touch: false,

--- a/src/quantecon_book_theme/assets/scripts/index.js
+++ b/src/quantecon_book_theme/assets/scripts/index.js
@@ -383,7 +383,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const authors = document.getElementsByClassName(
       "qe-page__header-authors",
     )[0];
-
+    const fontSize = authors.getAttribute("font-size");
     const h1 = document.querySelector(".main-index h1");
 
     // check if its the main toc page
@@ -393,6 +393,10 @@ document.addEventListener("DOMContentLoaded", function () {
     // creating a p tag for styling and author links
     const newParagraph = document.createElement("p");
     newParagraph.setAttribute("id", "qe-page-author-links");
+    newParagraph.setAttribute(
+      "style",
+      fontSize ? `font-size: ${fontSize}px` : "",
+    );
 
     //check if there are authors
     const isAuthor =

--- a/src/quantecon_book_theme/assets/styles/index.scss
+++ b/src/quantecon_book_theme/assets/styles/index.scss
@@ -759,10 +759,14 @@ tt {
 
 .main-index {
   h1 {
+    font-weight: 700;
+    margin-bottom: 0px;
+    padding: 0 0 1rem 0;
+  }
+  #qe-page-author-links {
     border-bottom: 5px solid #0072bc;
     margin: 0 0 2rem 0;
     padding: 0 0 1rem 0;
-    font-weight: 700;
   }
 }
 

--- a/src/quantecon_book_theme/assets/styles/index.scss
+++ b/src/quantecon_book_theme/assets/styles/index.scss
@@ -302,6 +302,10 @@ h1 {
   font-weight: 900;
   font-size: 3rem;
   margin: 0 0 1rem 0;
+  p {
+    margin: 0.25rem 0 0;
+    font-size: 0.9rem;
+  }
 }
 
 h2 {

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
@@ -149,7 +149,7 @@
 
                     </div>
                     <!-- length 2, since its a string and empty dict has length 2 - {} -->
-                    {%- if theme_authors | length > 2 %}
+                    {%- if theme_authors | length > 0 %}
                         <p class="qe-page__header-authors">
                             {% for author in theme_authors %}
                                 <a href="{{ author.url }}" target="_blank"><span>{{ author.name }}</span></a>

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
@@ -150,7 +150,7 @@
                     </div>
                     <!-- length 2, since its a string and empty dict has length 2 - {} -->
                     {%- if theme_authors | length > 0 %}
-                        <p class="qe-page__header-authors" font-size="{{theme_author_font_size}}">
+                        <p class="qe-page__header-authors" font-size="{{theme_mainpage_author_fontsize}}">
                             {% for author in theme_authors %}
                                 {% if loop.last and theme_authors|length >= 2 %}
                                     and <a href="{{ author.url }}" target="_blank"><span>{{ author.name }}</span></a>
@@ -162,7 +162,7 @@
                             {% endfor %}
                         </p>
                     {%- else %}
-                        <p class="qe-page__header-authors" font-size="{{theme_author_font_size}}">{{ author }}</p>
+                        <p class="qe-page__header-authors" font-size="{{theme_mainpage_author_fontsize}}">{{ author }}</p>
                     {%- endif %}
 
 

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
@@ -148,8 +148,17 @@
                         <p class="qe-page__header-subheading">{{ pagetitle | e }}</p>
 
                     </div>
+                    <!-- length 2, since its a string and empty dict has length 2 - {} -->
+                    {%- if theme_authors | length > 2 %}
+                        <p class="qe-page__header-authors">
+                            {% for author in theme_authors %}
+                                <a href="{{ author.url }}" target="_blank"><span>{{ author.name }}</span></a>
+                            {% endfor %}
+                        </p>
+                    {%- else %}
+                        <p class="qe-page__header-authors">{{ author }}</p>
+                    {%- endif %}
 
-                    <p class="qe-page__header-authors">{{ author }}</p>
 
                 </div> <!-- .page__header -->
 

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
@@ -150,7 +150,7 @@
                     </div>
                     <!-- length 2, since its a string and empty dict has length 2 - {} -->
                     {%- if theme_authors | length > 0 %}
-                        <p class="qe-page__header-authors" style="font-size: {{ theme_author_font_size }}px;">
+                        <p class="qe-page__header-authors" font-size="{{theme_author_font_size}}">
                             {% for author in theme_authors %}
                                 {% if loop.last and theme_authors|length >= 2 %}
                                     and <a href="{{ author.url }}" target="_blank"><span>{{ author.name }}</span></a>
@@ -162,7 +162,7 @@
                             {% endfor %}
                         </p>
                     {%- else %}
-                        <p class="qe-page__header-authors" style="font-size: {{ theme_author_font_size }}px;">{{ author }}</p>
+                        <p class="qe-page__header-authors" font-size="{{theme_author_font_size}}">{{ author }}</p>
                     {%- endif %}
 
 

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
@@ -152,7 +152,13 @@
                     {%- if theme_authors | length > 0 %}
                         <p class="qe-page__header-authors">
                             {% for author in theme_authors %}
-                                <a href="{{ author.url }}" target="_blank"><span>{{ author.name }}</span></a>
+                                {% if loop.last and theme_authors|length >= 2 %}
+                                    and <a href="{{ author.url }}" target="_blank"><span>{{ author.name }}</span></a>
+                                {% elif loop.first and theme_authors|length <= 2 %}
+                                    <a href="{{ author.url }}" target="_blank"><span>{{ author.name }}</span></a>
+                                {% else %}
+                                    <a href="{{ author.url }}" target="_blank"><span>{{ author.name }}</span></a>,
+                                {% endif %}
                             {% endfor %}
                         </p>
                     {%- else %}

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/theme.conf
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/theme.conf
@@ -30,4 +30,4 @@ og_logo_url =
 persistent_sidebar = False
 dark_logo =
 authors =
-author_font_size = 10
+author_font_size = 18

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/theme.conf
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/theme.conf
@@ -30,4 +30,4 @@ og_logo_url =
 persistent_sidebar = False
 dark_logo =
 authors =
-author_font_size = 18
+mainpage_author_fontsize = 18

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/theme.conf
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/theme.conf
@@ -29,3 +29,4 @@ twitter_logo_url =
 og_logo_url =
 persistent_sidebar = False
 dark_logo =
+authors = {}

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/theme.conf
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/theme.conf
@@ -29,4 +29,4 @@ twitter_logo_url =
 og_logo_url =
 persistent_sidebar = False
 dark_logo =
-authors = {}
+authors =


### PR DESCRIPTION

<img width="1194" alt="Screen Shot 2023-12-11 at 1 57 09 pm" src="https://github.com/QuantEcon/quantecon-book-theme/assets/6542997/124d9ad4-8bf8-4572-9da6-15e7f532e3d3">


Author names from the description need to be removed from individual repos. 

fixes https://github.com/QuantEcon/quantecon-book-theme/issues/233