### PR TITLE
[Dark Theme] Text Colours for Titles and SideBar

### DIFF
--- a/src/quantecon_book_theme/assets/styles/index.scss
+++ b/src/quantecon_book_theme/assets/styles/index.scss
@@ -14,6 +14,7 @@ $breakpoint-sm: 576px;
 $color-primary: #0072bc;
 $color-secondary: #d8655e;
 $color-body: #444444;
+$color-body-light: #888888;
 
 @import "normalize";
 @import "html5boilerplate";
@@ -192,6 +193,11 @@ body {
       }
     }
 
+    .toc-entry {
+      a.nav-link {
+        color: rgb(166, 166, 166);
+      }
+    }
     .reference.external,
     .reference.internal {
       font-weight: 800;
@@ -704,7 +710,7 @@ tt {
       flex-shrink: 0;
 
       a {
-        color: $color-body !important;
+        color: $color-body;
       }
 
       @media (max-width: $breakpoint-md) {


### PR DESCRIPTION
This PR introduces the following colour: 

<img width="1192" alt="Screen Shot 2023-12-17 at 9 06 19 pm" src="https://github.com/QuantEcon/quantecon-book-theme/assets/6542997/6e7ea057-15ea-4925-8059-fec1aa8f656c">

Please refer to the issue https://github.com/QuantEcon/quantecon-book-theme/issues/235

fixes https://github.com/QuantEcon/quantecon-book-theme/issues/235

