### PR TITLE
ENH:  Added ability to redirect to external pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           git clone https://github.com/executablebooks/sphinx-exercise.git
           cd sphinx-exercise
-          python setup.py install
+          python -m pip install .
           cd ../ && rm -rf sphinx-exercise
       - name: Install Dependencies
         shell: bash -l {0}

--- a/src/quantecon_book_theme/assets/scripts/index.js
+++ b/src/quantecon_book_theme/assets/scripts/index.js
@@ -377,6 +377,44 @@ document.addEventListener("DOMContentLoaded", function () {
   })();
 
   /**
+   * Redirect to a URL and paste the content in admonition
+   */
+  (function () {
+    let redirect = document.getElementById("redirect");
+    console.log(redirect, "redirect url");
+    if (redirect) {
+      window.location.href =
+        redirect.getAttribute("data-url") +
+        "?redirected_from=" +
+        window.location.pathname +
+        "&content=" +
+        redirect.getAttribute("data-content");
+    }
+  })();
+
+  /**
+   * Get the path redirected from
+   */
+  (function () {
+    let redirectedFrom = window.location.search;
+    if (redirectedFrom.includes("redirected_from")) {
+      // Create a URLSearchParams object from the query string
+      var searchParams = new URLSearchParams(redirectedFrom);
+      // Get the value of a particular variable from the query string
+      var redirectedFromUrl = searchParams.get("redirected_from");
+      var redirectedFromContent = searchParams.get("content");
+      if (redirectedFromContent) {
+        var admonition = document.getElementsByClassName(
+          "redirect-admonition",
+        )[0];
+        admonition.classList.remove("hidden");
+        var para = admonition.getElementsByTagName("p")[1];
+        para.innerHTML = redirectedFromContent;
+      }
+    }
+  })();
+
+  /**
    * Add authors to the heading of toc page
    */
   (function () {

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
@@ -85,9 +85,14 @@
     <div class="qe-wrapper">
 
         <div class="qe-main">
-
+            {%- if pagename in theme_redirects %}
+                <div id="redirect" data-url="{{theme_redirects[pagename]['url']}}" data-content="{{theme_redirects[pagename]['redirect_text']}}"></div>
+            {%- endif %}
             <div class="qe-page" id={{pagename}}>
-
+                <div class="redirect-admonition warning admonition hidden">
+                    <p class="admonition-title">Redirected Page</p>
+                    <p></p>
+                </div>
                 <div class="qe-page__toc">
 
                     <div class="inner">
@@ -99,8 +104,6 @@
                             On this page
                         </div>
                         {%- endif %}
-
-
                         <nav id="bd-toc-nav" class="qe-page__toc-nav">
                             {{ page_toc }}
                             <p class="logo">

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/theme.conf
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/theme.conf
@@ -31,3 +31,4 @@ persistent_sidebar = False
 dark_logo =
 authors =
 mainpage_author_fontsize = 18
+redirects =


### PR DESCRIPTION
Added a config variable to specify redirects. 

An Example:-

If in lecture-python, _config.yml file

```
redirects: 
        heavy_tails: 
          "url" : "file:///Users/u6533564/Documents/Office/Quantecon/lecture-python-intro/lectures/_build/html/heavy_tails.html"
          "redirect_text": "This page has been redirected from intro/heavy_tails.html"
``` 

Then, the page at heavy_tails in lecture-python will be redirected to the target URL,  with information about where it is redirected from and the content in the URL. Like:-
` ?redirected_from=/Users/u6533564/Documents/Office/Quantecon/lecture-python.myst/lectures/_build/html/heavy_tails.html&content=This page has been redirected from intro/heavy_tails.html`

The target page, on detecting the variables in the URL, displays the following admonition:

<img width="1260" alt="Screen Shot 2024-03-18 at 12 04 18 am" src="https://github.com/QuantEcon/quantecon-book-theme/assets/6542997/819d9f6c-2c1d-42f0-8857-dc95cdb0c309">
