### PR TITLE
Adjust admonition title background specificity to allow proof override

### DIFF
--- a/src/quantecon_book_theme/assets/styles/index.scss
+++ b/src/quantecon_book_theme/assets/styles/index.scss
@@ -953,23 +953,6 @@ tt {
     }
   }
 
-  .admonition {
-    font-size: 0.9rem;
-    margin: 1.5rem auto;
-    padding: 0 1rem 0.5rem 1rem;
-    page-break-inside: avoid;
-    box-shadow: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.1),
-      0 0 0.05rem rgba(0, 0, 0, 0.1);
-
-    .admonition-title {
-      position: relative;
-      margin: 0 -1rem;
-      padding: 0.25rem 2rem;
-      font-weight: 700;
-      background-color: #0072bc26;
-    }
-  }
-
   a.copybtn {
     top: 0.4em;
     opacity: 0.2;
@@ -1207,6 +1190,22 @@ tt {
       margin-left: auto;
       margin-right: auto;
     }
+  }
+}
+
+div.admonition, .admonition {
+  font-size: 0.9rem;
+  margin: 1.5rem auto;
+  padding: 0 1rem 0.5rem 1rem;
+  page-break-inside: avoid;
+  box-shadow: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.1),
+  0 0 0.05rem rgba(0, 0, 0, 0.1);
+  > .admonition-title {
+    position: relative;
+    margin: 0 -1rem;
+    padding: 0.25rem 2rem;
+    font-weight: 700;
+    background-color: #0072bc26;
   }
 }
 


### PR DESCRIPTION
By changing the way we address the admonition title, we allow the sphinx proof stylesheet to affect background colour when using QuantEcon book theme.

Addressing: https://github.com/QuantEcon/lecture-python-intro/pull/493
