### PR TITLE
MAINT: update libsass and docutils pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "sphinx>=5,<6",
   "docutils",
   "click",
-  "libsass~=0.20.1",
+  "libsass~=0.23.0",
   "sphinx_book_theme~=1.1.0",
   "beautifulsoup4",
 ]
@@ -63,7 +63,7 @@ doc = [
     "sphinx-togglebutton>=0.2.1",
     "sphinx-thebe",
     "sphinx-copybutton",
-    "docutils==0.17.1", # docutils 0.18, 0.19 need a patch fix https://sourceforge.net/p/docutils/patches/195/, un-pin when 0.20 is released
+    "docutils>=0.20",
     "plotly",
     "sphinxcontrib-bibtex>=2.2.0,<=2.5.0",
 ]

--- a/src/quantecon_book_theme/__init__.py
+++ b/src/quantecon_book_theme/__init__.py
@@ -12,7 +12,7 @@ from sphinx.util.osutil import ensuredir
 
 from .launch import add_hub_urls
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"
 """quantecon-book-theme version"""
 
 SPHINX_LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
This PR

- [x] fixes libsass for windows compatibility
- [x] removes `docutils` pin with release of `>0.20` 