### PR TITLE
ENH: enable links to github repo rather than document for view source

### DIFF
--- a/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
@@ -250,7 +250,11 @@
                     {%- else %}
                         <li data-tippy-content="Download PDF" onClick="window.print()"><i data-feather="file"></i></li>
                     {%- endif %}
-                    <li data-tippy-content="View Source"><a target="_blank" href="{{ theme_repository_url }}{{github_sourcefolder}}/{{ sourcename }}" download><i data-feather="github"></i></a></li>
+                    <!-- 
+                    # Enable if looking for link to specific document hosted on GitHub
+                    <li data-tippy-content="View Source"><a target="_blank" href="{{ theme_repository_url }}{{github_sourcefolder}}/{{ sourcename }}" download><i data-feather="github"></i></a></li> 
+                    -->
+                    <li data-tippy-content="View Source"><a target="_blank" href="{{ theme_repository_url }}" download><i data-feather="github"></i></a></li> 
                 </ul>
 
             </div>

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
@@ -250,11 +250,11 @@
                     {%- else %}
                         <li data-tippy-content="Download PDF" onClick="window.print()"><i data-feather="file"></i></li>
                     {%- endif %}
-                    <!-- 
+                    <!--
                     # Enable if looking for link to specific document hosted on GitHub
-                    <li data-tippy-content="View Source"><a target="_blank" href="{{ theme_repository_url }}{{github_sourcefolder}}/{{ sourcename }}" download><i data-feather="github"></i></a></li> 
+                    <li data-tippy-content="View Source"><a target="_blank" href="{{ theme_repository_url }}{{github_sourcefolder}}/{{ sourcename }}" download><i data-feather="github"></i></a></li>
                     -->
-                    <li data-tippy-content="View Source"><a target="_blank" href="{{ theme_repository_url }}" download><i data-feather="github"></i></a></li> 
+                    <li data-tippy-content="View Source"><a target="_blank" href="{{ theme_repository_url }}" download><i data-feather="github"></i></a></li>
                 </ul>
 
             </div>


### PR DESCRIPTION
This PR updates the functionality for `View Source` button to link to the hosting repo rather than the full path to the repo + document. `QuantEcon` has decided this would be more robust and useful (see https://github.com/QuantEcon/meta/issues/133)