### PR TITLE
ENH: Optional QuantEcon logo in titlebar with Theme Adjustments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,14 @@ repos:
     rev: 6.0.0
     hooks:
     - id: flake8
+      # E221 multiple spaces before operator
+      # E222 multiple spaces after operator
+      # E231 missing whitespace after ','
+      # E201 whitespace after '{'
+      # E202 whitespace before '}'
+      # E203 whitespace before ':'
+      # W503 line break before binary operator
+      args: ["--ignore=E201,E202,E203,E221,E222,E231,W503"]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0-alpha.4

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -9,6 +9,20 @@ to use MyST markdown with your Sphinx website,
 see [the MyST-parser documentation](https://myst-parser.readthedocs.io/)
 ```
 
+## Disabling QuantEcon Official Components
+
+If you are a project using this theme please use
+
+```python
+html_theme_options = {
+    ...
+    "quantecon_project": False,
+    ...
+}
+```
+
+as this will remove the QuantEcon logo from the top toolbar. 
+
 ## Source repository buttons
 
 There are a collection of buttons that you can use to link back to your source

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -23,7 +23,7 @@ html_theme_options = {
 
 as this will remove the QuantEcon logo from the top toolbar.
 
-This will also override some colors styles for a slightly different look 
+This will also override some colors styles for a slightly different look
 for the theme.
 
 ## Source repository buttons

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -21,7 +21,10 @@ html_theme_options = {
 }
 ```
 
-as this will remove the QuantEcon logo from the top toolbar. 
+as this will remove the QuantEcon logo from the top toolbar.
+
+This will also override some colors styles for a slightly different look 
+for the theme.
 
 ## Source repository buttons
 

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
@@ -79,6 +79,40 @@
 {%- endblock %}
 {%- block content %}
 
+<!-- Override QuantEcon theme colors -->
+{%- if not theme_quantecon_project %}
+<style>
+a {
+    color: #313131;
+}
+a:hover {
+    color: #313131;
+}
+a:visited {
+  color: #111111;
+}
+
+.main-index {
+  #qe-page-author-links {
+    border-bottom: 5px solid #313131;
+  }
+}
+
+.qe-page__header {
+  border-bottom: 5px solid #313131;
+}
+
+.qe-page__footer {
+    border-top: 5px solid #313131;
+}
+
+.toctree-wrapper {
+    .caption-text {
+        color: #111111
+    }
+}
+</style>
+{%- endif %}
 
     <span id="top"></span>
 

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
@@ -187,6 +187,8 @@
 
                     <p>Creative Commons License &ndash; This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International.</p>
 
+                    <p>A theme by <a href="https://quantecon.org">QuantEcon</a></p>
+
                 </footer> <!-- .page__footer -->
 
             </div> <!-- .page -->
@@ -225,7 +227,9 @@
                 <ul class="qe-toolbar__main">
                     <li data-tippy-content="Table of Contents" class="btn__sidebar"><i data-feather="menu"></i></li>
                     <li data-tippy-content="Home"><a href="{{ master_url }}"><i data-feather="home"></i></a></li>
+                    {%- if theme_quantecon_project %}
                     <li class="btn__qelogo"><a href="{{theme_header_organisation_url}}" title="{{html_title}}"><span class="show-for-sr">{{ theme_header_organisation}}</span></a></li>
+                    {%- endif %}
                 </ul>
 
                 <ul class="qe-toolbar__links">

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/theme.conf
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/theme.conf
@@ -3,6 +3,7 @@ inherit = pydata_sphinx_theme
 stylesheet = styles/quantecon-book-theme.css
 
 [options]
+quantecon_project = True
 single_page = False
 expand_toc_sections = []
 path_to_docs =


### PR DESCRIPTION
This PR

- enables configuration to remove the QuantEcon logo from the titlebar
- adds in footer text to indicate the theme was made by QuantEcon
- updates some theme colours when `quantecon_project = False`

## Usage

```python
html_theme_options = {
    ...
    "quantecon_project": False,
    ...
}
```

and if using `Jupyter-book`


```yaml
sphinx:
  config:
    html_theme_options:
      quantecon_project: False
```