### PR TITLE
FEAT: Replace italic and bold styling with color-based emphasis (TST: Claude Code Web)

### DIFF
--- a/src/quantecon_book_theme/assets/styles/_colors.scss
+++ b/src/quantecon_book_theme/assets/styles/_colors.scss
@@ -2,3 +2,7 @@ $primary: #0072bc;
 $secondary: #d8655e;
 $body: #444444;
 $body-light: #888888;
+
+// Semantic emphasis colors
+$emphasis: #0072bc;      // Blue for <em> - reuse primary
+$strong: #c7254e;        // Distinct red/magenta for <strong>

--- a/src/quantecon_book_theme/assets/styles/index.scss
+++ b/src/quantecon_book_theme/assets/styles/index.scss
@@ -119,6 +119,16 @@ body {
       color: #fff;
     }
 
+    // Color-based emphasis for dark mode
+    em {
+      color: #5eb3f6;  // Lighter blue for dark background
+    }
+
+    strong,
+    b {
+      color: #ff6b9d;  // Lighter magenta/pink for dark background
+    }
+
     .qe-toolbar__inner > ul > li > a,
     .qe-sidebar__nav ul > li > a {
       color: #fff;
@@ -367,9 +377,18 @@ h4 {
   color: #000;
 }
 
+// Replace italic emphasis with color-based emphasis
+em {
+  font-style: normal;
+  color: colors.$emphasis;
+  font-weight: 500;  // Slightly heavier for better readability
+}
+
 strong,
 b {
   font-weight: 700;
+  font-style: normal;
+  color: colors.$strong;
 }
 
 li {


### PR DESCRIPTION
This commit implements a new color-based emphasis system for better readability and visual distinction:

- Add semantic color variables ($emphasis, $strong) to _colors.scss
- Replace <em> italic styling with normal font weight + blue color (#0072bc)
- Add distinct red/magenta color (#c7254e) for <strong> tags
- Implement dark mode variants with lighter colors for better contrast:
  - <em>: #5eb3f6 (light blue)
  - <strong>: #ff6b9d (light pink/magenta)
- All colors meet WCAG AA contrast requirements (4.5:1 ratio)

Benefits:
- Improved readability with clearer visual hierarchy
- Better accessibility through semantic HTML + color differentiation
- Consistent with modern typography practices
- Maintains accessibility with proper contrast ratios

Closes #323

**Note:** This is testing Claude Code Web agent. 