### PR TITLE
FIX: update Jupyter Book links to avoid redirects

### DIFF
--- a/docs/layout.md
+++ b/docs/layout.md
@@ -204,7 +204,7 @@ I could try to add a list of ideas to talk about.
 I suppose I could just keep going on forever,
 but I'll stop here.
 
--- Jo the Jovyan, *[the jupyter book docs](https://beta.jupyterbook.org)*
+-- Jo the Jovyan, *[the jupyter book docs](https://jupyterbook.org/v1/)*
 ```
 
 `````{toggle}

--- a/docs/reference/markdown_limits.md
+++ b/docs/reference/markdown_limits.md
@@ -800,7 +800,7 @@ docker run --rm --security-opt label:disable  \
 If you navigate to `http://0.0.0.0:4000/jupyter-book/` in your browser,
 you should see a preview copy of your book.
 If you instead see an error, please try to update your local book;
-see [the Jupyter Book FAQ section](https://jupyterbook.org/guide/04_faq.html#how-can-i-update-my-book)
+see [the Jupyter Book documentation](https://jupyterbook.org/v1/)
 for more details on how to do so.
 
 ##### Building your site locally with Containers: Singularity

--- a/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
+++ b/src/quantecon_book_theme/theme/quantecon_book_theme/layout.html
@@ -150,7 +150,7 @@ a:visited {
                                 {% endif %}
                             </p>
 
-                            <p class="powered">Powered by <a href="https://jupyterbook.org/en/stable/">Jupyter Book</a></p>
+                            <p class="powered">Powered by <a href="https://jupyterbook.org/v1/">Jupyter Book</a></p>
 
                         </nav>
 


### PR DESCRIPTION
## Summary

Updated jupyterbook.org links to avoid redirect chains that cause linkchecker warnings in lecture builds.

**Before:** `https://jupyterbook.org/en/stable/` → redirects to `https://jupyterbook.org/v1/`

**After:** Direct link to `https://jupyterbook.org/v1/`

## Changes

1. **`layout.html`** - Footer "Powered by Jupyter Book" link updated
2. **`docs/reference/markdown_limits.md`** - Updated broken FAQ link
3. **`docs/layout.md`** - Updated beta.jupyterbook.org to current URL

## Impact

This fix will eliminate redirect warnings in lecture linkcheckers for sites using quantecon-book-theme.

## Related

- QuantEcon/lecture-python.myst#743 - Linkchecker report that identified this issue