### PR TITLE
fix: add explicit h5 heading styles to maintain size hierarchy

### DIFF
--- a/src/quantecon_book_theme/assets/styles/_base.scss
+++ b/src/quantecon_book_theme/assets/styles/_base.scss
@@ -148,7 +148,7 @@ h4 {
 }
 
 h5 {
-  font-size: 1.0rem;
+  font-size: 1rem;
   font-family: "Source Sans Pro", sans-serif;
   font-weight: 900;
   color: #000;

--- a/src/quantecon_book_theme/assets/styles/_base.scss
+++ b/src/quantecon_book_theme/assets/styles/_base.scss
@@ -147,6 +147,13 @@ h4 {
   color: #000;
 }
 
+h5 {
+  font-size: 1.0rem;
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: 900;
+  color: #000;
+}
+
 // Emphasis styling - replace italics with color and semi-bold weight
 em {
   font-style: normal;


### PR DESCRIPTION
## Summary

Fixes an issue where `h5` headings appeared visually larger than `h4` headings, breaking the expected heading size hierarchy.

**Example:** This was observed on pages like [JAX Introduction](https://python-programming.quantecon.org/jax_intro.html) where h5 sub-headings (e.g. "14.1.2.1.1. With NumPy") appeared as large as or larger than the h4 heading above them (e.g. "14.1.2.1. Speed!").

## Root Cause

`h5` had **no dedicated CSS rule** in `_base.scss`. It only inherited from the general heading selector:

```scss
h1, h2, h3, h4, h5 {
  font-weight: normal;
  font-family: "PT Serif", serif;
  color: #444;
}
```

Meanwhile, `h4` was explicitly styled with:

```scss
h4 {
  font-size: 1.2rem;
  font-family: "Source Sans Pro", sans-serif;
  font-weight: 900;
  color: #000;
}
```

Two factors combined to make `h5` appear larger than `h4`:

1. **No explicit font-size** — `h5` fell back to the browser default size rather than a size smaller than `h4`'s `1.2rem`.
2. **Different font family** — `h5` inherited "PT Serif" (a serif font with larger visual glyph metrics) while `h4` used "Source Sans Pro" (a more compact sans-serif), amplifying the perceived size difference.

## Fix

Added an explicit `h5` rule that maintains the descending heading hierarchy:

```scss
h5 {
  font-size: 1.0rem;
  font-family: "Source Sans Pro", sans-serif;
  font-weight: 900;
  color: #000;
}
```

### Heading size hierarchy (after fix)

| Heading | Font Size | Font Family |
|---------|-----------|-------------|
| h1 | 2.0em | PT Serif |
| h2 | 1.7rem | PT Serif |
| h3 | 1.4rem | PT Serif |
| h4 | 1.2rem | Source Sans Pro |
| **h5** | **1.0rem** | **Source Sans Pro** |
