### PR TITLE
ci: switch update-snapshots workflow to fixtures repo (prep for #390)

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -3,6 +3,12 @@ on:
   issue_comment:
     types: [created]
 
+# Snapshots are generated against quantecon-book-theme-fixtures at this
+# pinned SHA. Keep this in sync with .github/workflows/ci.yml.
+env:
+  FIXTURES_REPO: QuantEcon/quantecon-book-theme-fixtures
+  FIXTURES_SHA: d8ffc17c753ecf45fa25c6062827e1aa9de201b3
+
 jobs:
   # /update-new-snapshots — only creates MISSING snapshots (safe for adding new tests)
   update-new-snapshots:
@@ -33,31 +39,27 @@ jobs:
           ref: ${{ steps.pr.outputs.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fetch lecture-python-programming
-        shell: bash -l {0}
-        run: |
-          git clone --branch quantecon-book-theme https://github.com/QuantEcon/lecture-python-programming
-
-      - name: Setup Anaconda
-        uses: conda-incubator/setup-miniconda@v4
+      - name: Checkout fixtures
+        uses: actions/checkout@v6
         with:
-          auto-update-conda: true
-          auto-activate-base: true
-          miniconda-version: 'latest'
+          repository: ${{ env.FIXTURES_REPO }}
+          ref: ${{ env.FIXTURES_SHA }}
+          path: fixtures
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
           python-version: "3.13"
-          environment-file: lecture-python-programming/environment.yml
-          activate-environment: lecture-python-programming
+          cache: "pip"
 
-      - name: Install quantecon-book-theme
-        shell: bash -l {0}
+      - name: Install fixtures build deps + this PR's theme
         run: |
-          python -m pip install .
+          pip install -r fixtures/requirements.txt
+          pip install .
 
-      - name: Build HTML
-        shell: bash -l {0}
-        run: |
-          cd lecture-python-programming
-          jb build lectures --path-output ./
+      - name: Build fixtures site
+        working-directory: fixtures
+        run: jb build . --warningiserror
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -74,7 +76,7 @@ jobs:
         continue-on-error: true
         run: npx playwright test --update-snapshots=missing
         env:
-          SITE_PATH: lecture-python-programming/_build/html
+          SITE_PATH: fixtures/_build/html
 
       - name: Commit and Push Updated Snapshots
         run: |
@@ -140,31 +142,27 @@ jobs:
           ref: ${{ steps.pr.outputs.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fetch lecture-python-programming
-        shell: bash -l {0}
-        run: |
-          git clone --branch quantecon-book-theme https://github.com/QuantEcon/lecture-python-programming
-
-      - name: Setup Anaconda
-        uses: conda-incubator/setup-miniconda@v4
+      - name: Checkout fixtures
+        uses: actions/checkout@v6
         with:
-          auto-update-conda: true
-          auto-activate-base: true
-          miniconda-version: 'latest'
+          repository: ${{ env.FIXTURES_REPO }}
+          ref: ${{ env.FIXTURES_SHA }}
+          path: fixtures
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
           python-version: "3.13"
-          environment-file: lecture-python-programming/environment.yml
-          activate-environment: lecture-python-programming
+          cache: "pip"
 
-      - name: Install quantecon-book-theme
-        shell: bash -l {0}
+      - name: Install fixtures build deps + this PR's theme
         run: |
-          python -m pip install .
+          pip install -r fixtures/requirements.txt
+          pip install .
 
-      - name: Build HTML
-        shell: bash -l {0}
-        run: |
-          cd lecture-python-programming
-          jb build lectures --path-output ./
+      - name: Build fixtures site
+        working-directory: fixtures
+        run: jb build . --warningiserror
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -181,7 +179,7 @@ jobs:
         continue-on-error: true
         run: npx playwright test --update-snapshots
         env:
-          SITE_PATH: lecture-python-programming/_build/html
+          SITE_PATH: fixtures/_build/html
 
       - name: Upload Old vs New Diff
         uses: actions/upload-artifact@v7

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -4,7 +4,9 @@ on:
     types: [created]
 
 # Snapshots are generated against quantecon-book-theme-fixtures at this
-# pinned SHA. Keep this in sync with .github/workflows/ci.yml.
+# pinned SHA. ci.yml will be migrated to the same fixtures repo in #390
+# (it still builds lecture-python-programming on main today); once that
+# lands, keep FIXTURES_SHA in sync between the two workflows.
 env:
   FIXTURES_REPO: QuantEcon/quantecon-book-theme-fixtures
   FIXTURES_SHA: d8ffc17c753ecf45fa25c6062827e1aa9de201b3


### PR DESCRIPTION
## Summary

Lands the `update-snapshots.yml` workflow change from #390 ahead of the
rest of that migration. **Workflow-only change** — no other files
touched.

## Why split it out

`issue_comment` triggers (which the snapshot-update workflow uses) always
run from the **default branch's** workflow file. While #390 sits as a PR,
\`/update-new-snapshots\` on it would load the OLD workflow from \`main\`,
clone \`lecture-python-programming\`, and run it against the NEW
fixture-path spec on the PR branch — producing 404-page screenshots as
baselines (we got lucky a parallel push prevented those from being
committed).

Once **this** PR is merged, \`main\`'s update-snapshots workflow correctly
clones \`quantecon-book-theme-fixtures\` at the pinned SHA and builds it,
so \`/update-new-snapshots\` on #390 will produce correct baselines.

## Scope

- **Only changed:** \`.github/workflows/update-snapshots.yml\`
- **Not changed:** \`ci.yml\`, \`tox.ini\`, \`playwright.config.ts\`,
  \`theme.spec.ts\` — all stay on lecture-python-programming until #390
  merges. ci.yml is intentionally excluded because changing it without
  the matching spec/tox would break the visual job on every open PR.

## Safety

- Only triggers are \`/update-snapshots\` / \`/update-new-snapshots\` PR
  comments. No automatic runs.
- After merge, if someone comments \`/update-new-snapshots\` on an
  unrelated open PR (e.g. #388), the new workflow will build fixtures
  and run that PR's spec — which still expects lecture-python paths and
  will 404. Verified that **no such trigger comment exists** on any open
  PR right now (only #388 and #390 are open, neither has the comment).

## Test plan

- [ ] Merge this PR
- [ ] Confirm CI on this PR passes (only \`continuous-integration\`
      should run; the visual workflow does not gate this PR)
- [ ] On #390, comment \`/update-new-snapshots\` once this is merged
- [ ] Confirm the workflow run on #390 (a) clones fixtures, (b) builds
      with \`jb build . --warningiserror\`, (c) generates baselines, (d)
      commits them to the #390 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)