### PR TITLE
ci: split visual + preview into independent jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,19 @@ env:
   FIXTURES_REPO: QuantEcon/quantecon-book-theme-fixtures
   FIXTURES_SHA: d8ffc17c753ecf45fa25c6062827e1aa9de201b3
 
+# Explicit least-privilege permissions:
+#   contents: read         — checkout + upload-artifact
+#   actions: read          — download-artifact (cross-job)
+#   pull-requests: write   — daun/playwright-report-summary (PR comment from
+#                            visual job) and nwtgck/actions-netlify (preview
+#                            URL comment from preview job)
+# Without this block the workflow relies on the repo/org default GITHUB_TOKEN
+# permissions, which can flip read-only and silently break PR commenting.
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
 # The CI is split into three jobs so the Netlify preview deploys regardless
 # of whether visual regression tests pass. Reviewers need the preview link
 # to *decide* whether failing visual tests reflect intentional design changes
@@ -122,6 +135,13 @@ jobs:
 
   preview:
     needs: build
+    # Skip on forks: PRs from fork repos don't get NETLIFY_AUTH_TOKEN /
+    # NETLIFY_SITE_ID secrets, so the deploy would fail and block external
+    # contributors' CI. Matches the codecov guard pattern in tests.yml:51.
+    if: >
+      github.repository == 'QuantEcon/quantecon-book-theme' &&
+      (github.event_name == 'push' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: Download fixtures build artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,21 @@ env:
   FIXTURES_REPO: QuantEcon/quantecon-book-theme-fixtures
   FIXTURES_SHA: d8ffc17c753ecf45fa25c6062827e1aa9de201b3
 
+# The CI is split into three jobs so the Netlify preview deploys regardless
+# of whether visual regression tests pass. Reviewers need the preview link
+# to *decide* whether failing visual tests reflect intentional design changes
+# (in which case they comment /update-snapshots) or genuine regressions.
+# Previously the preview was a later step of a single job and got skipped on
+# visual-test failure — exactly the case where reviewers need it most.
+#
+#   build  →  visual   (gate; may fail)
+#          ↘
+#            preview   (always runs; uploads the artifact reviewers eyeball)
+#
+# `build` produces the fixtures HTML once; `visual` and `preview` consume it
+# in parallel via actions/upload-artifact + download-artifact.
 jobs:
-  tests:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout theme
@@ -41,22 +54,44 @@ jobs:
         working-directory: fixtures
         run: jb build . --warningiserror
 
-      # Visual Regression Testing
+      - name: Upload fixtures build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: fixtures-build
+          path: fixtures/_build/html/
+          retention-days: 1
+
+  visual:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout theme
+        uses: actions/checkout@v6
+
+      - name: Download fixtures build artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: fixtures-build
+          path: fixtures/_build/html/
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
+
       - name: Install Playwright
         run: |
           npm ci
           npx playwright install --with-deps chromium
+
       - name: Run Visual Regression Tests
         id: visual-tests
         run: npm run test:visual
         continue-on-error: true
         env:
           SITE_PATH: fixtures/_build/html
+
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v7
         if: always()
@@ -64,6 +99,7 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
       - name: Upload Test Results (on failure)
         uses: actions/upload-artifact@v7
         if: steps.visual-tests.outcome == 'failure'
@@ -71,6 +107,7 @@ jobs:
           name: visual-test-diff
           path: test-results/
           retention-days: 30
+
       - name: Post Visual Test Results to PR
         uses: daun/playwright-report-summary@v3
         if: github.event_name == 'pull_request'
@@ -78,9 +115,20 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           report-file: playwright-report/results.json
           comment-title: '🎭 Visual Regression Test Results'
+
       - name: Fail if Visual Tests Failed
         if: steps.visual-tests.outcome == 'failure'
         run: exit 1
+
+  preview:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download fixtures build artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: fixtures-build
+          path: fixtures/_build/html/
 
       - name: Preview Deploy to Netlify
         uses: nwtgck/actions-netlify@v3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CI
+- **Split visual regression CI into `build` / `visual` / `preview` jobs** — the Netlify preview now deploys regardless of whether visual tests pass, since reviewers need the preview link to decide whether failing visual tests reflect intentional design changes (in which case they `/update-snapshots`) or genuine regressions. Previously the preview was a later step of a single job and got skipped on visual-test failure. `visual` and `preview` both consume the fixtures build artifact produced by `build`; visual failure no longer blocks preview deploy.
+
 ## [0.20.3] - 2026-04-14
 
 ### Fixed


### PR DESCRIPTION
## Summary

Decouples the Netlify preview deploy from the visual regression gate, so the preview always deploys regardless of whether visual tests pass.

## Why

Spotted while working on #388. The single-job `ci.yml` ran visual tests, then conditionally deployed Netlify only if everything succeeded:

\`\`\`
Run Visual Regression Tests   (continue-on-error: true)
Upload artifacts
Post PR comment
Fail if Visual Tests Failed   ← exits with 1 on failure
Preview Deploy to Netlify     ← skipped on failure
\`\`\`

So for any PR with intentional design changes (the entire point of \`/update-snapshots\`), the workflow failed before the preview deployed — exactly the case where reviewers need the preview link to decide whether the diff is intentional. Chicken-and-egg.

## What changes

Single \`tests\` job → three jobs (\`build\`, \`visual\`, \`preview\`):

\`\`\`
build  →  visual   (gate; may fail, posts PR comment)
       ↘
         preview   (always runs; deploys Netlify regardless of visual)
\`\`\`

- \`build\` checks out theme + fixtures, installs deps, runs \`jb build\`, and uploads \`fixtures/_build/html\` as an \`actions/upload-artifact\` artifact
- \`visual\` and \`preview\` both \`needs: build\`, download the artifact, and run in parallel
- Neither depends on the other — visual failure no longer blocks preview

### Trade-offs considered

- **Versus reordering steps in a single job** (the minimal fix): rejected because conceptual separation of "test" and "preview" is the actual win here. Future maintainers reading the workflow will see independent jobs with clear responsibilities, rather than steps in a sequence where ordering matters.
- **Versus splitting into separate workflow files**: rejected because that would duplicate the build steps (~1 min of fixtures clone + pip install + \`jb build\`) per CI run.
- **Versus uploading artifact and consuming in two jobs**: chosen — single build, two consumers, no duplication.

## Branch protection

Verified main is not currently protected with required status checks. The single \`tests\` job → three jobs (\`build\` / \`visual\` / \`preview\`) renames are safe; no required check needs migration.

## Test plan

- [x] CI runs on this PR; all three jobs visible
- [x] \`build\` succeeds and uploads the artifact
- [x] \`visual\` succeeds (no design changes here; baselines should match)
- [ ] \`preview\` succeeds and posts the Netlify URL
- [ ] Open a future PR with intentional visual changes — confirm \`visual\` fails but \`preview\` still deploys

## Follow-ups

- Once this lands, future PRs (incl. #388 and any other layout work) automatically get preview-on-visual-failure behaviour. No change needed in PR #388 itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)