### PR TITLE
security: resolve npm Dependabot alerts, add npm ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,13 @@ updates:
       prefix: ⬆️
     schedule:
       interval: weekly
+  - package-ecosystem: npm
+    directory: /
+    commit-message:
+      prefix: ⬆️
+    schedule:
+      interval: monthly
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CI
+- **Cleared open Dependabot security alerts via `npm audit fix`** — `webpack-dev-server` 5.2.2→5.2.4 (GHSA-79cf-xcqc-c78w), `shell-quote` 1.8.1→1.8.4 (GHSA-w7jw-789q-3m8p, critical), `qs` 6.14.2→6.15.2 (GHSA-q8mj-m7cp-5q26), `ws` 8.18.0→8.21.0 (GHSA-58qx-3vcg-4xpx). All transitive dev/build-time only; built theme assets unchanged. The remaining `uuid` alert (GHSA-w5hq-g745-h8pq) was dismissed as not exploitable — `sockjs` only calls `uuid.v4()`, the advisory affects `v3`/`v5`/`v6` with a caller-provided `buf`.
+- **Dependabot now watches npm** — added an `npm` ecosystem entry to `dependabot.yml` (monthly, grouped into a single PR) alongside the existing `github-actions` config.
+
 ## [0.21.0] - 2026-06-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -203,6 +203,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@noble/hashes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@parcel/watcher": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.4.1.tgz",
@@ -490,6 +503,175 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
+        "node_modules/@peculiar/asn1-cms": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+            "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.7.0",
+                "@peculiar/asn1-x509": "^2.7.0",
+                "@peculiar/asn1-x509-attr": "^2.7.0",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-csr": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+            "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.7.0",
+                "@peculiar/asn1-x509": "^2.7.0",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-ecc": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+            "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.7.0",
+                "@peculiar/asn1-x509": "^2.7.0",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pfx": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+            "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.7.0",
+                "@peculiar/asn1-pkcs8": "^2.7.0",
+                "@peculiar/asn1-rsa": "^2.7.0",
+                "@peculiar/asn1-schema": "^2.7.0",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pkcs8": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+            "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.7.0",
+                "@peculiar/asn1-x509": "^2.7.0",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pkcs9": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+            "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.7.0",
+                "@peculiar/asn1-pfx": "^2.7.0",
+                "@peculiar/asn1-pkcs8": "^2.7.0",
+                "@peculiar/asn1-schema": "^2.7.0",
+                "@peculiar/asn1-x509": "^2.7.0",
+                "@peculiar/asn1-x509-attr": "^2.7.0",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-rsa": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+            "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.7.0",
+                "@peculiar/asn1-x509": "^2.7.0",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-schema": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+            "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-x509": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+            "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.7.0",
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-x509-attr": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+            "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.7.0",
+                "@peculiar/asn1-x509": "^2.7.0",
+                "asn1js": "^3.0.6",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+            "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/x509": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+            "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.6.0",
+                "@peculiar/asn1-csr": "^2.6.0",
+                "@peculiar/asn1-ecc": "^2.6.0",
+                "@peculiar/asn1-pkcs9": "^2.6.0",
+                "@peculiar/asn1-rsa": "^2.6.0",
+                "@peculiar/asn1-schema": "^2.6.0",
+                "@peculiar/asn1-x509": "^2.6.0",
+                "pvtsutils": "^1.3.6",
+                "reflect-metadata": "^0.2.2",
+                "tslib": "^2.8.1",
+                "tsyringe": "^4.10.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/@playwright/test": {
             "version": "1.57.0",
             "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
@@ -584,16 +766,16 @@
             "license": "MIT"
         },
         "node_modules/@types/express": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-            "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+            "version": "4.17.25",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+            "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.33",
                 "@types/qs": "*",
-                "@types/serve-static": "*"
+                "@types/serve-static": "^1"
             }
         },
         "node_modules/@types/express-serve-static-core": {
@@ -695,16 +877,6 @@
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.19.2"
-            }
-        },
-        "node_modules/@types/node-forge": {
-            "version": "1.3.11",
-            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
-            "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
             }
         },
         "node_modules/@types/qs": {
@@ -1175,6 +1347,21 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/asn1js": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+            "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.5",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/baseline-browser-mapping": {
             "version": "2.9.19",
             "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -1206,9 +1393,9 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.4",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-            "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+            "version": "1.20.5",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1220,7 +1407,7 @@
                 "http-errors": "~2.0.1",
                 "iconv-lite": "~0.4.24",
                 "on-finished": "~2.4.1",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "raw-body": "~2.5.3",
                 "type-is": "~1.6.18",
                 "unpipe": "~1.0.0"
@@ -1357,6 +1544,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/bytestreamjs": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+            "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -2370,15 +2567,15 @@
             }
         },
         "node_modules/express": {
-            "version": "4.22.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-            "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+            "version": "4.22.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+            "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "~1.20.3",
+                "body-parser": "~1.20.5",
                 "content-disposition": "~0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "~0.7.1",
@@ -2397,7 +2594,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "~0.1.12",
                 "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
+                "qs": "~6.15.1",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "~0.19.0",
@@ -3567,16 +3764,6 @@
             "license": "MIT",
             "optional": true
         },
-        "node_modules/node-forge": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-            "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-            "dev": true,
-            "license": "(BSD-3-Clause OR GPL-2.0)",
-            "engines": {
-                "node": ">= 6.13.0"
-            }
-        },
         "node_modules/node-releases": {
             "version": "2.0.27",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -3823,6 +4010,24 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/pkijs": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+            "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@noble/hashes": "1.4.0",
+                "asn1js": "^3.0.6",
+                "bytestreamjs": "^2.0.1",
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.3",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/playwright": {
@@ -4532,10 +4737,30 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/pvtsutils": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+            "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/pvutils": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+            "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/qs": {
-            "version": "6.14.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -4646,6 +4871,13 @@
             "engines": {
                 "node": ">= 10.13.0"
             }
+        },
+        "node_modules/reflect-metadata": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+            "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/relateurl": {
             "version": "0.2.7",
@@ -4880,17 +5112,17 @@
             "license": "MIT"
         },
         "node_modules/selfsigned": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-            "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+            "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/node-forge": "^1.3.0",
-                "node-forge": "^1"
+                "@peculiar/x509": "^1.14.2",
+                "pkijs": "^3.3.3"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/semver": {
@@ -5087,11 +5319,14 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-            "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+            "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -5679,9 +5914,29 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-            "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/tsyringe": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+            "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^1.9.3"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/tsyringe/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true,
             "license": "0BSD"
         },
@@ -5948,15 +6203,15 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
-            "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+            "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/bonjour": "^3.5.13",
                 "@types/connect-history-api-fallback": "^1.5.4",
-                "@types/express": "^4.17.21",
+                "@types/express": "^4.17.25",
                 "@types/express-serve-static-core": "^4.17.21",
                 "@types/serve-index": "^1.9.4",
                 "@types/serve-static": "^1.15.5",
@@ -5966,9 +6221,9 @@
                 "bonjour-service": "^1.2.1",
                 "chokidar": "^3.6.0",
                 "colorette": "^2.0.10",
-                "compression": "^1.7.4",
+                "compression": "^1.8.1",
                 "connect-history-api-fallback": "^2.0.0",
-                "express": "^4.21.2",
+                "express": "^4.22.1",
                 "graceful-fs": "^4.2.6",
                 "http-proxy-middleware": "^2.0.9",
                 "ipaddr.js": "^2.1.0",
@@ -5976,7 +6231,7 @@
                 "open": "^10.0.3",
                 "p-retry": "^6.2.0",
                 "schema-utils": "^4.2.0",
-                "selfsigned": "^2.4.1",
+                "selfsigned": "^5.5.0",
                 "serve-index": "^1.9.1",
                 "sockjs": "^0.3.24",
                 "spdy": "^4.0.2",
@@ -6130,9 +6385,9 @@
             "license": "MIT"
         },
         "node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
## Summary

Resolves all 4 open [Dependabot security alerts](https://github.com/QuantEcon/quantecon-book-theme/security/dependabot) plus one additional `npm audit` finding. All affected packages are transitive **devDependencies** under `webpack-dev-server` (local dev / CI build only) — nothing in the shipped theme assets or Python package changes.

### Lockfile updates (`npm audit fix`, all semver-compatible)

| Alert | Package | Change | Advisory |
|---|---|---|---|
| #77 (critical) | shell-quote | 1.8.1 → 1.8.4 | GHSA-w7jw-789q-3m8p |
| #76 | qs | 6.14.2 → 6.15.2 | GHSA-q8mj-m7cp-5q26 |
| #73 | webpack-dev-server | 5.2.2 → 5.2.4 | GHSA-79cf-xcqc-c78w |
| — (npm audit) | ws | 8.18.0 → 8.21.0 | GHSA-58qx-3vcg-4xpx |

### Alert #75 (uuid) — dismissed, not patched

`sockjs` pins `uuid@^8` so no compatible patched version exists, and the vulnerable code is unused: the advisory (GHSA-w5hq-g745-h8pq) affects `v3`/`v5`/`v6` with a caller-provided `buf`, while sockjs only calls `uuid.v4()` with no arguments. Dismissed on the alert with reason *vulnerable code is not actually used*.

### Dependabot config

Added an `npm` package-ecosystem entry to `dependabot.yml` (monthly, grouped into a single PR) — previously only `github-actions` was covered, which is why these alerts never got automatic fix PRs.

## Verification

- `npm run build` succeeds; webpack emits identical assets ("compared for emit")
- `npm audit` reports 0 vulnerabilities outside the dismissed uuid/sockjs chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)