### PR TITLE
test: wait for stable page height before visual snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### CI
+- **Stabilized flaky mobile-chrome visual tests on math-heavy pages** — after the Playwright 1.57→1.60 (Chromium) bump in #400, `math`/`proofs`/`cross-references` full-page screenshots intermittently rendered ~60px shorter than baseline, failing Playwright's dimension check before pixel tolerances apply. `waitForReady` now waits for `document.fonts.ready` and polls until the document height holds steady for 750ms, instead of a fixed 500ms sleep after MathJax typesetting.
 - **Cleared open Dependabot security alerts via `npm audit fix`** — `webpack-dev-server` 5.2.2→5.2.4 (GHSA-79cf-xcqc-c78w), `shell-quote` 1.8.1→1.8.4 (GHSA-w7jw-789q-3m8p, critical), `qs` 6.14.2→6.15.2 (GHSA-q8mj-m7cp-5q26), `ws` 8.18.0→8.21.0 (GHSA-58qx-3vcg-4xpx). All transitive dev/build-time only; built theme assets unchanged. The remaining `uuid` alert (GHSA-w5hq-g745-h8pq) was dismissed as not exploitable — `sockjs` only calls `uuid.v4()`, the advisory affects `v3`/`v5`/`v6` with a caller-provided `buf`.
 - **Dependabot now watches npm** — added an `npm` ecosystem entry to `dependabot.yml` (monthly, grouped into a single PR) alongside the existing `github-actions` config.
 

--- a/tests/visual/theme.spec.ts
+++ b/tests/visual/theme.spec.ts
@@ -13,7 +13,9 @@ import { test, expect, Page } from "@playwright/test";
  */
 
 // Wait for the page to fully settle, including MathJax typesetting when the
-// page contains math. Pages without MathJax resolve immediately.
+// page contains math (pages without MathJax pass the typeset gate
+// immediately; the font and height-stability waits below apply to every
+// page).
 //
 // After MathJax's startup promise resolves, font loading and late reflow
 // can still shift the total page height for a short window. Full-page
@@ -22,6 +24,9 @@ import { test, expect, Page } from "@playwright/test";
 // pages were observed settling ~60px apart between runs on mobile-chrome.
 // Instead of sleeping, wait for web fonts and then require the document
 // height to hold steady across consecutive polls.
+//
+// NB: waitForFunction's second positional parameter is `arg` (forwarded to
+// the page function) — `timeout`/`polling` options must go third.
 async function waitForReady(page: Page) {
   await page.waitForLoadState("networkidle");
   await page.waitForFunction(
@@ -30,9 +35,14 @@ async function waitForReady(page: Page) {
       if (!mj || !mj.startup || !mj.startup.promise) return true;
       return mj.startup.promise.then(() => true);
     },
+    undefined,
     { timeout: 15000 }
   );
-  await page.evaluate(() => document.fonts.ready.then(() => true));
+  await page.waitForFunction(
+    () => document.fonts.ready.then(() => true),
+    undefined,
+    { timeout: 15000 }
+  );
   // Stable means three consecutive 250ms polls (750ms) without the
   // document height changing.
   await page.waitForFunction(
@@ -50,6 +60,7 @@ async function waitForReady(page: Page) {
       }
       return w.__qeStablePolls >= 3;
     },
+    undefined,
     { timeout: 15000, polling: 250 }
   );
 }

--- a/tests/visual/theme.spec.ts
+++ b/tests/visual/theme.spec.ts
@@ -14,6 +14,14 @@ import { test, expect, Page } from "@playwright/test";
 
 // Wait for the page to fully settle, including MathJax typesetting when the
 // page contains math. Pages without MathJax resolve immediately.
+//
+// After MathJax's startup promise resolves, font loading and late reflow
+// can still shift the total page height for a short window. Full-page
+// screenshots fail outright on any dimension mismatch (before pixel
+// tolerances apply), so a fixed post-typeset delay isn't enough: math-heavy
+// pages were observed settling ~60px apart between runs on mobile-chrome.
+// Instead of sleeping, wait for web fonts and then require the document
+// height to hold steady across consecutive polls.
 async function waitForReady(page: Page) {
   await page.waitForLoadState("networkidle");
   await page.waitForFunction(
@@ -24,7 +32,26 @@ async function waitForReady(page: Page) {
     },
     { timeout: 15000 }
   );
-  await page.waitForTimeout(500);
+  await page.evaluate(() => document.fonts.ready.then(() => true));
+  // Stable means three consecutive 250ms polls (750ms) without the
+  // document height changing.
+  await page.waitForFunction(
+    () => {
+      const w = window as any;
+      const height = Math.max(
+        document.body.scrollHeight,
+        document.documentElement.scrollHeight
+      );
+      if (w.__qeLastHeight === height) {
+        w.__qeStablePolls = (w.__qeStablePolls ?? 0) + 1;
+      } else {
+        w.__qeLastHeight = height;
+        w.__qeStablePolls = 0;
+      }
+      return w.__qeStablePolls >= 3;
+    },
+    { timeout: 15000, polling: 250 }
+  );
 }
 
 // hasMath: true loosens the snapshot tolerance for that page. MathJax font


### PR DESCRIPTION
## Summary

Fixes the flaky `visual` job seen on `main` after #400 merged ([failing run](https://github.com/QuantEcon/quantecon-book-theme/actions/runs/27243772737) — passed on re-run with no code change).

## The flake

After the Playwright 1.57→1.60 (Chromium) bump, `mobile-chrome` full-page screenshots of math-heavy fixtures (`math`, `proofs`, `cross-references`) intermittently rendered **~60px shorter** than baseline (2888–2891px vs 2950px), with the height varying even between retries of the same run. `toHaveScreenshot` fails outright on any dimension mismatch *before* pixel tolerances apply, so the `maxDiffPixelRatio: 0.05` these pages already have never helped.

Root cause: MathJax's `startup.promise` resolving doesn't mean layout is final — font loading and late reflow can still shift total page height. The fixed `waitForTimeout(500)` was a race that Chromium's new timing made lossy.

## The fix

`waitForReady` now, after the existing MathJax wait:
1. awaits `document.fonts.ready`, and
2. polls every 250ms until the document height is unchanged for three consecutive polls (750ms stable), with the same 15s timeout as the MathJax wait.

This targets the observed failure mode directly while keeping full-page coverage on all three affected pages (rather than the `fullPage: false` escape hatch, which sacrifices coverage). Baselines are intentionally **not** regenerated — the passing runs show 2950px is still the settled height; re-snapshotting mid-flake would just capture a coin flip.

## Verification

- `visual` job on this PR runs the full suite with the new wait.
- I'll re-run the job a second time before merge for extra confidence, since a single green run can't distinguish "fixed" from "lucky".

🤖 Generated with [Claude Code](https://claude.com/claude-code)