### PR TITLE
Point the README's docs link at the live GitHub Pages site

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ html_theme_options = {
 pygments_style = 'friendly'  # or 'monokai', 'github-dark', etc.
 ```
 
-See the [full documentation](https://quantecon-book-theme.readthedocs.io/) for all configuration options.
+See the [full documentation](https://quantecon.github.io/quantecon-book-theme/) for all configuration options.
 
 ## Development
 


### PR DESCRIPTION
The README's "See the [full documentation]" link points at `https://quantecon-book-theme.readthedocs.io/`, which **404s** — there is no Read the Docs project for this theme.

The docs are built and deployed by `.github/workflows/docs.yml` to GitHub Pages at <https://quantecon.github.io/quantecon-book-theme/>, which is also what the repository's own homepage field points to. This repoints the link there.

One line changed; it is the only occurrence of the dead URL in the repository (other `readthedocs.io` links in the tree belong to third-party projects and are fine).

Found while documenting the QuantEcon themes in the operations manual — see QuantEcon/QuantEcon.manual#148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
