### PR TITLE
fix: suppress default Sphinx author placeholder

### DIFF
--- a/src/quantecon_book_theme/__init__.py
+++ b/src/quantecon_book_theme/__init__.py
@@ -618,7 +618,9 @@ def add_to_context(app, pagename, templatename, context, doctree):
         context["theme_description"] = description
 
     # Add the author if it exists
-    if app.config.author != "unknown":
+    if app.config.author in {"unknown", "Author name not set"}:
+        context.pop("author", None)
+    else:
         context["author"] = app.config.author
 
     # Absolute URLs for logo if `html_baseurl` is given

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -190,6 +190,10 @@ def test_build_book(file_regression, sphinx_build):
 
     # Check a few components that should be true on each page
     index_html = sphinx_build.get("index.html")
+    assert (
+        index_html.find("p", class_="qe-page__header-authors").get_text(strip=True)
+        == "Executable Book Project"
+    )
     sidebar = index_html.find_all(attrs={"class": "bd-sidebar"})[0]
     file_regression.check(sidebar.prettify(), extension=".html")
 
@@ -218,6 +222,29 @@ def test_build_book(file_regression, sphinx_build):
         extension=".html",
     )
     sphinx_build.clean()
+
+
+def test_build_book_without_author(tmp_path):
+    """Do not render Sphinx's default author placeholder in the page header."""
+    path_book = tmp_path / "book"
+    copytree(path_base, path_book)
+
+    path_conf = path_book / "conf.py"
+    conf = path_conf.read_text(encoding="utf8")
+    path_conf.write_text(
+        conf.replace('author = "Executable Book Project"\n', ""), encoding="utf8"
+    )
+
+    check_output(["sphinx-build", ".", "_build/html", "-a", "-W"], cwd=path_book)
+    index_html = BeautifulSoup(
+        (path_book / "_build" / "html" / "index.html").read_text(encoding="utf8"),
+        "html.parser",
+    )
+
+    assert (
+        index_html.find("p", class_="qe-page__header-authors").get_text(strip=True)
+        == ""
+    )
 
 
 # def test_navbar_options(file_regression, sphinx_build):


### PR DESCRIPTION
## Summary

- clear Sphinx's known default author placeholders from the final page context;
- remove an author value already populated by the parent theme instead of leaving stale text behind;
- add a real-Sphinx regression for an omitted `author`, with the existing explicit-author path retained as a control.

This remains intentionally separate from #427: that merged work changes configured author/translators attribution but retains the exact fallback `app.config.author` guard fixed here.

Closes #428.

## Regression evidence

Before the source fix, the new test failed under Python 3.12 / Sphinx 7.4.7 with:

```text
AssertionError: assert 'Author name not set' == ''
```

After the fix, the focused no-author build passes with both Sphinx 7 and Sphinx 8.

## Validation

Rebased onto current `main` at `649cc376`; range-diff and stable patch IDs confirm the rebased commit is patch-identical to the reviewed head.

- `uvx --with tox-uv tox -e py312-sphinx7,py312-sphinx8 -- tests/test_build.py -k author` — passed in both environments (1 passed, 9 deselected each).
- `uvx --with tox-uv tox -e py312-sphinx7,py312-sphinx8,py313-sphinx7,py313-sphinx8 -- -k 'not git_functions_unit'` — 216 passed and 1 deselected in each environment (864 passing test executions total).
- `uvx --with tox-uv tox -e py313-pre-commit -- --all-files` — all hooks passed.
- `uvx --with tox-uv tox -e docs-update` — passed on the rebased head.

The unfiltered four-environment matrix reaches 216 passing tests in every environment, then fails only `test_git_functions_unit` because its POSIX `/nonexistent/path` fixture raises `NotADirectoryError` on Windows. An untouched current-main baseline at `649cc376` reproduced that exact failure, so Linux CI remains the final unfiltered platform proof.

## Provenance

This contribution was prepared autonomously by OpenAI Codex under the `LunaMeerkats` account. The issue claim, implementation, validation results, and limitations are disclosed directly.