### PR TITLE
ci: re-pin fixtures to the merged byline demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,18 @@ on:
 # PRs. To bump the pin, update FIXTURES_SHA below.
 env:
   FIXTURES_REPO: QuantEcon/quantecon-book-theme-fixtures
-  # Includes the announcement-banner demo (merged in fixtures #1) and the
-  # author/translator byline demo (fixtures #2), so the preview/visual build
-  # exercises both. Points at the fixtures #2 branch head rather than a merge
-  # commit: that PR's own self-check builds against the latest *released*
-  # theme, which does not know the `translators` option yet, so it stays red
-  # until this ships. Re-pin to the merge commit once it does.
-  FIXTURES_SHA: ab9ba206d48870e86b822c74380546e42fcba299
+  # Includes the announcement-banner demo (fixtures #1) and the author and
+  # translator byline demo (fixtures #2), so the preview/visual build
+  # exercises both.
+  #
+  # Adding a fixtures demo of a brand-new theme option is a two-step dance:
+  # the fixtures repo's own self-check installs the latest *released* theme
+  # and builds with --warningiserror, so it fails with "unsupported theme
+  # option" until that option ships. Pin this to the fixtures branch head to
+  # get the demo under test here (this repo installs the PR's own theme), then
+  # re-pin to the merge commit after the release. Options inherited from
+  # pydata_sphinx_theme, such as `announcement`, skip the dance entirely.
+  FIXTURES_SHA: 0048d104ed1afa587b824d130e5210dc969713c5
 
 # Explicit least-privilege permissions:
 #   contents: write        — checkout + upload-artifact + nwtgck/actions-netlify

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -11,7 +11,7 @@ on:
 # "Resolve fixtures pin" step.
 env:
   FIXTURES_REPO: QuantEcon/quantecon-book-theme-fixtures
-  FIXTURES_SHA: ab9ba206d48870e86b822c74380546e42fcba299
+  FIXTURES_SHA: 0048d104ed1afa587b824d130e5210dc969713c5
 
 jobs:
   # /update-new-snapshots — only creates MISSING snapshots (safe for adding new tests)


### PR DESCRIPTION
Points `FIXTURES_SHA` at the fixtures #2 merge commit (`0048d10`) instead of that PR's branch head.

The branch-head pin was deliberate but temporary. The fixtures repo's own self-check installs the latest *released* theme and builds with `--warningiserror`, so it failed with "unsupported theme option 'translators'" until v0.22.0 shipped. Pinning to the branch head let this repo test the demo anyway, since CI here installs the PR's own theme. v0.22.0 is now on PyPI, the fixtures PR is green and merged, so the pin can point somewhere permanent.

No baseline churn expected: the squash-merge commit and the branch head have byte-identical trees, verified with `git diff`.

The comment above the pin is rewritten to describe the two-step dance generally rather than this one instance, since it will catch the next person adding a fixtures demo of a new theme option. Options inherited from pydata_sphinx_theme, such as `announcement`, skip it entirely — which is why the banner demo never hit this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
